### PR TITLE
Added --history-limit option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ The contents of index.yaml will be printed to stdout and the program will exit. 
 - `--index-limit=<number>` - limit the number of parallel indexers
 - `--context-path=<path>` - base context path (new root for application routes)
 - `--depth=<number>` - levels of nested repos for multitenancy
+- `--history-limit=<number>` - limit the number of version saved per chart, 0 means no limit
 
 ### Docker Image
 Available via [Docker Hub](https://hub.docker.com/r/chartmuseum/chartmuseum/).

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -69,6 +69,7 @@ func cliHandler(c *cli.Context) {
 		IndexLimit:             conf.GetInt("indexlimit"),
 		Depth:                  conf.GetInt("depth"),
 		MaxUploadSize:          conf.GetInt("maxuploadsize"),
+		HistoryLimit:           conf.GetInt("history-limit"),
 	}
 
 	server, err := newServer(options)

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -33,6 +33,7 @@ type (
 		IndexLimit             int
 		Depth                  int
 		MaxUploadSize          int
+		HistoryLimit           int
 	}
 
 	// Server is a generic interface for web servers
@@ -78,6 +79,7 @@ func NewServer(options ServerOptions) (Server, error) {
 		EnableAPI:              options.EnableAPI,
 		UseStatefiles:          options.UseStatefiles,
 		AllowOverwrite:         options.AllowOverwrite,
+		HistoryLimit:           options.HistoryLimit,
 	})
 
 	return server, err

--- a/pkg/chartmuseum/server/multitenant/api.go
+++ b/pkg/chartmuseum/server/multitenant/api.go
@@ -76,12 +76,34 @@ func (server *MultiTenantServer) uploadChartPackage(log cm_logger.LoggingFn, rep
 	if limitReached {
 		return &HTTPError{507, "repo has reached storage limit"}
 	}
-	log(cm_logger.DebugLevel,"Adding package to storage",
+	log(cm_logger.DebugLevel, "Adding package to storage",
 		"package", filename,
 	)
 	err = server.StorageBackend.PutObject(pathutil.Join(repo, filename), content)
 	if err != nil {
 		return &HTTPError{500, err.Error()}
+	}
+
+	if server.HistoryLimit != 0 {
+		name, err := cm_repo.ChartNameFromContent(content)
+		if err != nil {
+			return &HTTPError{500, err.Error()}
+		}
+		chartVersions, httpErr := server.getChart(log, repo, name)
+		if httpErr != nil {
+			return httpErr
+		}
+		if len(chartVersions) > server.HistoryLimit {
+			for _, version := range chartVersions[server.HistoryLimit:] {
+				log(cm_logger.DebugLevel, "Removing old charts",
+					"chart", name,
+					"version", version)
+				httpErr = server.deleteChartVersion(log, repo, name, version.Metadata.Version)
+				if httpErr != nil {
+					return httpErr
+				}
+			}
+		}
 	}
 	return nil
 }
@@ -104,7 +126,7 @@ func (server *MultiTenantServer) uploadProvenanceFile(log cm_logger.LoggingFn, r
 	if limitReached {
 		return &HTTPError{507, "repo has reached storage limit"}
 	}
-	log(cm_logger.DebugLevel,"Adding provenance file to storage",
+	log(cm_logger.DebugLevel, "Adding provenance file to storage",
 		"provenance_file", filename,
 	)
 	err = server.StorageBackend.PutObject(pathutil.Join(repo, filename), content)

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -35,6 +35,7 @@ type (
 		InternalCacheStore     map[string]*cacheEntry
 		MaxStorageObjects      int
 		IndexLimit             int
+		HistoryLimit           int
 		AllowOverwrite         bool
 		APIEnabled             bool
 		UseStatefiles          bool
@@ -57,6 +58,7 @@ type (
 		ProvPostFormFieldName  string
 		MaxStorageObjects      int
 		IndexLimit             int
+		HistoryLimit           int
 		GenIndex               bool
 		AllowOverwrite         bool
 		EnableAPI              bool
@@ -96,6 +98,7 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 		InternalCacheStore:     map[string]*cacheEntry{},
 		MaxStorageObjects:      options.MaxStorageObjects,
 		IndexLimit:             options.IndexLimit,
+		HistoryLimit:           options.HistoryLimit,
 		ChartURL:               chartURL,
 		ChartPostFormFieldName: options.ChartPostFormFieldName,
 		ProvPostFormFieldName:  options.ProvPostFormFieldName,

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -422,6 +422,15 @@ var configVars = map[string]configVar{
 			EnvVar: "DEPTH",
 		},
 	},
+	"historylimit": {
+		Type:    intType,
+		Default: 0,
+		CLIFlag: cli.IntFlag{
+			Name:   "history-limit",
+			Usage:  "Limit the maximum number of versions stored per chart",
+			EnvVar: "HISTORY_LIMIT",
+		},
+	},
 }
 
 func populateCLIFlags() {

--- a/pkg/repo/chart.go
+++ b/pkg/repo/chart.go
@@ -43,6 +43,15 @@ func ChartPackageFilenameFromContent(content []byte) (string, error) {
 	return filename, nil
 }
 
+// ChartNameFromContent return the name of the chart from the binary content
+func ChartNameFromContent(content []byte) (string, error) {
+	chart, err := chartFromContent(content)
+	if err != nil {
+		return "", err
+	}
+	return chart.Metadata.Name, nil
+}
+
 // ChartVersionFromStorageObject returns a chart version from a storage object
 func ChartVersionFromStorageObject(object storage.Object) (*helm_repo.ChartVersion, error) {
 	if len(object.Content) == 0 {
@@ -72,8 +81,8 @@ func ChartVersionFromStorageObject(object storage.Object) (*helm_repo.ChartVersi
 // StorageObjectFromChartVersion returns a storage object from a chart version (empty content)
 func StorageObjectFromChartVersion(chartVersion *helm_repo.ChartVersion) storage.Object {
 	object := storage.Object{
-		Path: pathutil.Base(chartVersion.URLs[0]),
-		Content: []byte{},
+		Path:         pathutil.Base(chartVersion.URLs[0]),
+		Content:      []byte{},
 		LastModified: chartVersion.Created,
 	}
 	return object

--- a/pkg/repo/chart_test.go
+++ b/pkg/repo/chart_test.go
@@ -100,10 +100,10 @@ func (suite *ChartTestSuite) TestChartVersionFromStorageObject() {
 }
 
 func (suite *ChartTestSuite) TestStorageObjectFromChartVersion() {
-	now :=  time.Now()
+	now := time.Now()
 	chartVersion := &helm_repo.ChartVersion{
-		URLs:     []string{"charts/mychart-0.1.0.tgz"},
-		Created:  now,
+		URLs:    []string{"charts/mychart-0.1.0.tgz"},
+		Created: now,
 	}
 	object := StorageObjectFromChartVersion(chartVersion)
 	suite.Equal(now, object.LastModified, "object last modified as expected")
@@ -121,6 +121,16 @@ func (suite *ChartTestSuite) TestChartPackageFilenameFromContent() {
 	suite.Equal("mychart-0.1.0.tgz", filename, "chart tarball filename as expected")
 }
 
+func (suite *ChartTestSuite) TestChartNameFromContent() {
+	chartName, err := ChartNameFromContent([]byte{})
+	suite.NotNil(err, "error getting tarball chart name with empty byte array")
+	suite.Equal("", chartName, "chart name blank with empty byte array")
+
+	chartName, err = ChartNameFromContent(suite.TarballContent)
+	suite.Nil(err, "no error getting chart name from test tarball content")
+	suite.Equal("mychart", chartName, "chart name as expected")
+
+}
 func TestChartTestSuite(t *testing.T) {
 	suite.Run(t, new(ChartTestSuite))
 }


### PR DESCRIPTION
Old chart versions are deleted when a chart is added

Implements https://github.com/kubernetes-helm/chartmuseum/issues/134