### PR TITLE
add RSA token validation

### DIFF
--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -92,7 +92,6 @@ func cliHandler(c *cli.Context) {
 		AuthService:            conf.GetString("authservice"),
 		AuthIssuer:             conf.GetString("authissuer"),
 		AuthCertPath:           conf.GetString("authcertpath"),
-		AuthScopes:             conf.GetString("authscopes"),
 	}
 
 	server, err := newServer(options)

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -86,6 +86,13 @@ func cliHandler(c *cli.Context) {
 		IndexLimit:             conf.GetInt("indexlimit"),
 		Depth:                  conf.GetInt("depth"),
 		MaxUploadSize:          conf.GetInt("maxuploadsize"),
+		BearerAuth:             conf.GetBool("bearerauth"),
+		AuthType:               conf.GetString("authtype"),
+		AuthRealm:              conf.GetString("authrealm"),
+		AuthService:            conf.GetString("authservice"),
+		AuthIssuer:             conf.GetString("authissuer"),
+		AuthCertPath:           conf.GetString("authcertpath"),
+		AuthScopes:             conf.GetString("authscopes"),
 	}
 
 	server, err := newServer(options)

--- a/pkg/chartmuseum/router/authorization.go
+++ b/pkg/chartmuseum/router/authorization.go
@@ -55,7 +55,6 @@ func (router *Router) authorizeRequest(request *http.Request) (bool, map[string]
 	} else if router.BearerAuthHeader != "" {
 		// used to escape spaces in service name
 		queryString := url.PathEscape("service=" + router.AuthService)
-		queryString += "&scope=registry:catalog:" + router.AuthScopes
 
 		if router.AnonymousGet && request.Method == "GET" {
 			authorized = true

--- a/pkg/chartmuseum/router/authorization.go
+++ b/pkg/chartmuseum/router/authorization.go
@@ -18,9 +18,7 @@ package router
 
 import (
 	"crypto/rsa"
-	"crypto/tls"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -38,35 +36,6 @@ func generateBasicAuthHeader(username string, password string) string {
 	base := username + ":" + password
 	basicAuthHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(base))
 	return basicAuthHeader
-}
-
-// generate a simple jwt from authorization server
-// TODO: this should be handled by a "responseHeaders["WWW-Authentication"] step I believe
-func getJWT(router *Router) string {
-	var token string
-
-	// TODO: using due to self-signed cert, needs removal
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-
-	queryString := url.PathEscape("service=" + router.AuthService + "&scope=registry:catalog:" + router.AuthScopes)
-
-	client := &http.Client{Transport: tr}
-	response, err := client.Get(router.AuthRealm + "?" + queryString)
-
-	if err != nil {
-		fmt.Printf("The HTTP request failed with error %s\n", err)
-		token = "invalid"
-	} else {
-		data, _ := ioutil.ReadAll(response.Body)
-
-		var response map[string]interface{}
-		json.Unmarshal([]byte(string(data)), &response)
-
-		token = response["token"].(string)
-	}
-	return token
 }
 
 func (router *Router) authorizeRequest(request *http.Request) (bool, map[string]string) {
@@ -87,14 +56,15 @@ func (router *Router) authorizeRequest(request *http.Request) (bool, map[string]
 		if router.AnonymousGet && request.Method == "GET" {
 			authorized = true
 		} else {
-			splitToken := strings.Split(request.Header.Get("Authorization"), "Bearer ")
-			_, isValid := validateJWT(splitToken[1], router)
-			if isValid {
-				authorized = true
+			if request.Header.Get("Authorization") != "" {
+				splitToken := strings.Split(request.Header.Get("Authorization"), "Bearer ")
+				_, isValid := validateJWT(splitToken[1], router)
+				if isValid {
+					authorized = true
+				}
 			} else {
-				// TODO: needs work: not redirecting to auth server correctly .
-				fmt.Println("Should redirect to Authorization server")
-
+				// TODO: needs work: Should I redirect to Auth Server? or just error as it does now.
+				// FIXME: I should probably move the scope out of this query string parsing as it is parsing * unnecessarly.
 				queryString := url.PathEscape("service=" + router.AuthService + "&scope=registry:catalog:" + router.AuthScopes)
 				responseHeaders["WWW-Authenticate"] = "Bearer realm=\"" + router.AuthRealm + "?" + queryString + "\""
 			}
@@ -102,10 +72,11 @@ func (router *Router) authorizeRequest(request *http.Request) (bool, map[string]
 	} else {
 		authorized = true
 	}
-
+	
 	return authorized, responseHeaders
 }
 
+// verify if JWT is valid by using the rsa public certificate pem
 // currently this only works with RSA key signing
 // TODO: how best to handle many different signing algorithms?
 func validateJWT(t string, router *Router) (*jwt.Token, bool) {

--- a/pkg/chartmuseum/router/router.go
+++ b/pkg/chartmuseum/router/router.go
@@ -45,7 +45,6 @@ type (
 		AuthService      string
 		AuthIssuer       string
 		AuthPublicCert   []byte
-		AuthScopes       string
 	}
 
 	// RouterOptions are options for constructing a Router
@@ -67,7 +66,6 @@ type (
 		AuthService   string
 		AuthIssuer    string
 		AuthCertPath  string
-		AuthScopes    string
 	}
 
 	// Route represents an application route
@@ -142,8 +140,6 @@ func NewRouter(options RouterOptions) *Router {
 
 		// loads certificate from file
 		loadPublicCertFromFile(options.AuthCertPath, router)
-
-		router.AuthScopes = options.AuthScopes
 
 		router.BearerAuthHeader = "Bearer"
 	}

--- a/pkg/chartmuseum/router/router.go
+++ b/pkg/chartmuseum/router/router.go
@@ -137,7 +137,7 @@ func NewRouter(options RouterOptions) *Router {
 
 		router.AuthScopes = options.AuthScopes
 
-		router.BearerAuthHeader = "Bearer " + getJWT(router)
+		router.BearerAuthHeader = "Bearer"
 	}
 
 	if options.Username != "" && options.Password != "" {
@@ -175,10 +175,7 @@ func (router *Router) masterHandler(c *gin.Context) {
 	c.Params = params
 
 	if isRepoAction(route.Action) {
-		// TODO: needs work
-		if router.BearerAuthHeader != "" {
-			c.Request.Header.Set("Authorization", router.BearerAuthHeader)
-		}
+
 
 		authorized, responseHeaders := router.authorizeRequest(c.Request)
 		for key, value := range responseHeaders {

--- a/pkg/chartmuseum/router/router.go
+++ b/pkg/chartmuseum/router/router.go
@@ -113,6 +113,12 @@ func NewRouter(options RouterOptions) *Router {
 	}
 
 	// if BearerAuth is true, looks for required inputs.
+	// example input:
+	// --bearer-auth=true
+	// --auth-realm="https://127.0.0.1:5001/auth" 
+	// --auth-service="chartmuseum" 
+	// --auth-issuer="Acme auth server"
+	// --auth-cert-path="./certs/authorization-server-cert.pem"
 	if options.BearerAuth {
 		if options.AuthRealm == "" {
 			router.Logger.Fatal("Missing Auth Realm")
@@ -126,7 +132,9 @@ func NewRouter(options RouterOptions) *Router {
 		if options.AuthCertPath == "" {
 			router.Logger.Fatal("Missing Auth Server Public Cert Path")
 		}
-		// TODO: currently only accepts Token, error if other value passed in.
+		if options.AuthType != "token" {
+			router.Logger.Fatal("Invalid auth type: only accept token auth")
+		}
 		router.AuthType = options.AuthType
 		router.AuthRealm = options.AuthRealm
 		router.AuthService = options.AuthService

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -52,6 +52,13 @@ type (
 		IndexLimit             int
 		Depth                  int
 		MaxUploadSize          int
+		BearerAuth             bool
+		AuthType               string
+		AuthRealm              string
+		AuthService            string
+		AuthIssuer             string
+		AuthCertPath           string
+		AuthScopes             string
 	}
 
 	// Server is a generic interface for web servers
@@ -86,6 +93,13 @@ func NewServer(options ServerOptions) (Server, error) {
 		AnonymousGet:  options.AnonymousGet,
 		Depth:         options.Depth,
 		MaxUploadSize: options.MaxUploadSize,
+		BearerAuth:    options.BearerAuth,
+		AuthType:      options.AuthType,
+		AuthRealm:     options.AuthRealm,
+		AuthService:   options.AuthService,
+		AuthIssuer:    options.AuthIssuer,
+		AuthCertPath:  options.AuthCertPath,
+		AuthScopes:    options.AuthScopes,
 	})
 
 	server, err := mt.NewMultiTenantServer(mt.MultiTenantServerOptions{

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -58,7 +58,6 @@ type (
 		AuthService            string
 		AuthIssuer             string
 		AuthCertPath           string
-		AuthScopes             string
 	}
 
 	// Server is a generic interface for web servers
@@ -99,7 +98,6 @@ func NewServer(options ServerOptions) (Server, error) {
 		AuthService:   options.AuthService,
 		AuthIssuer:    options.AuthIssuer,
 		AuthCertPath:  options.AuthCertPath,
-		AuthScopes:    options.AuthScopes,
 	})
 
 	server, err := mt.NewMultiTenantServer(mt.MultiTenantServerOptions{

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -447,6 +447,69 @@ var configVars = map[string]configVar{
 			EnvVar: "DEPTH",
 		},
 	},
+	"bearerauth": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "bearer-auth",
+			Usage:  "enable bearer auth",
+			EnvVar: "BEARER_AUTH",
+		},
+	},
+	"authtype": {
+		Type:    stringType,
+		Default: "token",
+		CLIFlag: cli.StringFlag{
+			Name:   "auth-type",
+			Usage:  "type of auth (currently only supports token)",
+			EnvVar: "AUTH_TYPE",
+		},
+	},
+	"authrealm": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "auth-realm",
+			Usage:  "authorization server url",
+			EnvVar: "AUTH_REALM",
+		},
+	},
+	"authservice": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "auth-service",
+			Usage:  "authorization server service name",
+			EnvVar: "AUTH_SERVICE",
+		},
+	},
+	"authissuer": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "auth-issuer",
+			Usage:  "authorization server name",
+			EnvVar: "AUTH_ISSUER",
+		},
+	},
+	"authcertpath": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "auth-cert-path",
+			Usage:  "path to authorization server public pem file",
+			EnvVar: "AUTH_CERT_PATH",
+		},
+	},
+	"authscopes": {
+		Type:    stringType,
+		Default: "*",
+		CLIFlag: cli.StringFlag{
+			Name:   "auth-scopes",
+			Usage:  "authentication scopes",
+			EnvVar: "AUTH_SCOPES",
+		},
+	},
 }
 
 func populateCLIFlags() {

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -501,15 +501,6 @@ var configVars = map[string]configVar{
 			EnvVar: "AUTH_CERT_PATH",
 		},
 	},
-	"authscopes": {
-		Type:    stringType,
-		Default: "*",
-		CLIFlag: cli.StringFlag{
-			Name:   "auth-scopes",
-			Usage:  "authentication scopes",
-			EnvVar: "AUTH_SCOPES",
-		},
-	},
 }
 
 func populateCLIFlags() {


### PR DESCRIPTION
As part of issue #59 this will allow chartmuseum to be configured to accept a token from an Authorization server (ex: [docker_auth](https://github.com/cesanta/docker_auth)) and verify its validity. The validation will only work for tokens signed with RSA at this time. 

To start using Bearer auth you will pass the following flags:
--bearer-auth=true
--auth-realm="<auth server endpoint>" 
--auth-service="<service name, ex: chartmuseum>" 
--auth-issuer="<name of auth server>"
--auth-cert-path="<path to auth server public cert pem file>"

Once added all endpoints will enforce auth. 

The validation will extract the token from the Authorization header, validate the token, and
allow/disallow the request (disallow will return 401 with responseHeader["WWW-Authenticate"] and the details for connecting to the Authorization server)

Currently we are not addressing Scopes on this PR and plan to complete that as a separate task.