### PR TITLE
Run chartmuseum binary as nonroot user in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.6
 RUN apk add --no-cache ca-certificates \
-&& adduser -D chartmuseum
+&& adduser -D -u 1000 chartmuseum
 COPY bin/linux/amd64/chartmuseum /chartmuseum
-USER chartmuseum
+USER 1000
 ENTRYPOINT ["/chartmuseum"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM alpine:3.6
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates \
+&& adduser -D chartmuseum
 COPY bin/linux/amd64/chartmuseum /chartmuseum
+USER chartmuseum
 ENTRYPOINT ["/chartmuseum"]


### PR DESCRIPTION
Chartmuseum is currently running as root in the container. This conflicts with Kubernetes clusters that have PodSecurityPolicy support enabled.

Warning Failed 5s (x3 over 18s) kubelet, k8s-prod-worker02 Error: container has runAsNonRoot and image will run as root

This PR adds a user to the container and runs chartmuseum as it.