### PR TITLE
Silence health route by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ The contents of index.yaml will be printed to stdout and the program will exit. 
 
 #### Other CLI options
 - `--log-json` - output structured logs as json
+- `--log-health` - log incoming /health requests
 - `--disable-api` - disable all routes prefixed with /api
 - `--disable-statefiles` - disable use of index-cache.yaml
 - `--allow-overwrite` - allow chart versions to be re-uploaded without ?force querystring

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -74,6 +74,7 @@ func cliHandler(c *cli.Context) {
 		ProvPostFormFieldName:  conf.GetString("provpostformfieldname"),
 		ContextPath:            conf.GetString("contextpath"),
 		LogJSON:                conf.GetBool("logjson"),
+		LogHealth:              conf.GetBool("loghealth"),
 		Debug:                  conf.GetBool("debug"),
 		EnableAPI:              !conf.GetBool("disableapi"),
 		UseStatefiles:          !conf.GetBool("disablestatefiles"),
@@ -116,7 +117,7 @@ func backendFromConfig(conf *config.Config) storage.Backend {
 	case "google":
 		backend = googleBackendFromConfig(conf)
 	case "oracle":
-		backend = oracleBackendFromConfig(conf)        
+		backend = oracleBackendFromConfig(conf)
 	case "microsoft":
 		backend = microsoftBackendFromConfig(conf)
 	case "alibaba":

--- a/pkg/chartmuseum/router/router.go
+++ b/pkg/chartmuseum/router/router.go
@@ -56,6 +56,7 @@ type (
 		TlsCert       string
 		TlsKey        string
 		PathPrefix    string
+		LogHealth     bool
 		EnableMetrics bool
 		AnonymousGet  bool
 		Depth         int
@@ -90,7 +91,7 @@ func NewRouter(options RouterOptions) *Router {
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()
 	engine.Use(gin.Recovery())
-	engine.Use(requestWrapper(options.Logger))
+	engine.Use(requestWrapper(options.Logger, options.LogHealth))
 	engine.Use(limits.RequestSizeLimiter(int64(options.MaxUploadSize)))
 
 	if options.EnableMetrics {
@@ -113,8 +114,8 @@ func NewRouter(options RouterOptions) *Router {
 	// if BearerAuth is true, looks for required inputs.
 	// example input:
 	// --bearer-auth=true
-	// --auth-realm="https://127.0.0.1:5001/auth" 
-	// --auth-service="chartmuseum" 
+	// --auth-realm="https://127.0.0.1:5001/auth"
+	// --auth-service="chartmuseum"
 	// --auth-issuer="Acme auth server"
 	// --auth-cert-path="./certs/authorization-server-cert.pem"
 	if options.BearerAuth {

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -40,6 +40,7 @@ type (
 		ProvPostFormFieldName  string
 		ContextPath            string
 		LogJSON                bool
+		LogHealth              bool
 		Debug                  bool
 		EnableAPI              bool
 		UseStatefiles          bool
@@ -88,6 +89,7 @@ func NewServer(options ServerOptions) (Server, error) {
 		ContextPath:   contextPath,
 		TlsCert:       options.TlsCert,
 		TlsKey:        options.TlsKey,
+		LogHealth:     options.LogHealth,
 		EnableMetrics: options.EnableMetrics,
 		AnonymousGet:  options.AnonymousGet,
 		Depth:         options.Depth,

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -67,6 +67,15 @@ var configVars = map[string]configVar{
 			EnvVar: "LOG_JSON",
 		},
 	},
+	"loghealth": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "log-health",
+			Usage:  "log inbound /health requests",
+			EnvVar: "LOG_HEALTH",
+		},
+	},
 	"disablemetrics": {
 		Type:    boolType,
 		Default: false,


### PR DESCRIPTION
Added `--log-health` option which will continue to display /health requests in log output

Fixes #172 