### PR TITLE
Allow disabling delete route for a server

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ The contents of index.yaml will be printed to stdout and the program will exit. 
 - `--log-json` - output structured logs as json
 - `--log-health` - log incoming /health requests
 - `--disable-api` - disable all routes prefixed with /api
+- `--disable-delete` - explicitely disable the delete chart route
 - `--disable-statefiles` - disable use of index-cache.yaml
 - `--allow-overwrite` - allow chart versions to be re-uploaded without ?force querystring
 - `--disable-force-overwrite` - do not allow chart versions to be re-uploaded, even with ?force querystring
@@ -487,27 +488,27 @@ ChartMuseum exposes its [Prometheus metrics](https://prometheus.io/docs/concepts
 Below are the current application metrics exposed. Note that there is a per tenant (repo) label. The repo label corresponds to the depth parameter, so a depth=2 as the example above would
 have repo labels named `org1/repoa` and `org2/repob`.
 
-| Metric                                   | Type           | Labels     | Description                              |
-| ---------------------------------------- | -------------- | ---------- | ---------------------------------------- |
-| chartmuseum_charts_served_total          | Gauge          | {repo="*"} | Total number of charts                   |
-| chartmuseum_charts_versions_served_total | Gauge          | {repo="*"} | Total number of chart versions available |
+| Metric                                   | Type  | Labels     | Description                              |
+| ---------------------------------------- | ----- | ---------- | ---------------------------------------- |
+| chartmuseum_charts_served_total          | Gauge | {repo="*"} | Total number of charts                   |
+| chartmuseum_charts_versions_served_total | Gauge | {repo="*"} | Total number of chart versions available |
 
 *: see above for repo label
 
 There are other general global metrics harvested (per process, hence for all tenants). You can get the complete list by using the `/metrics` route.
 
-| Metric                                       | Type    | Labels                                                | Description                               |
-| -------------------------------------------- | ------- | ----------------------------------------------------- | ----------------------------------------- |
-| chartmuseum_request_duration_seconds         | Summary | {quantile="0.5"}, {quantile="0.9"}, {quantile="0.99"} | The HTTP request latencies in seconds     |
-| chartmuseum_request_duration_seconds_sum     |         |                                                       |                                           |
-| chartmuseum_request_duration_seconds_count   |         |                                                       |                                           |
-| chartmuseum_request_size_bytes               | Summary | {quantile="0.5"}, {quantile="0.9"}, {quantile="0.99"} | The HTTP request sizes in bytes           |
-| chartmuseum_request_size_bytes_sum           |         |                                                       |                                           |
-| chartmuseum_request_size_bytes_count         |         |                                                       |                                           |
-| chartmuseum_response_size_bytes              | Summary | {quantile="0.5"}, {quantile="0.9"}, {quantile="0.99"} | The HTTP response sizes in bytes          |
-| chartmuseum_response_size_bytes_sum          |         |                                                       |                                           |
-| chartmuseum_response_size_bytes_count        |         |                                                       |                                           |
-| go_goroutines                                | Gauge   |                                                       | Number of goroutines that currently exist |
+| Metric                                     | Type    | Labels                                                | Description                               |
+| ------------------------------------------ | ------- | ----------------------------------------------------- | ----------------------------------------- |
+| chartmuseum_request_duration_seconds       | Summary | {quantile="0.5"}, {quantile="0.9"}, {quantile="0.99"} | The HTTP request latencies in seconds     |
+| chartmuseum_request_duration_seconds_sum   |         |                                                       |                                           |
+| chartmuseum_request_duration_seconds_count |         |                                                       |                                           |
+| chartmuseum_request_size_bytes             | Summary | {quantile="0.5"}, {quantile="0.9"}, {quantile="0.99"} | The HTTP request sizes in bytes           |
+| chartmuseum_request_size_bytes_sum         |         |                                                       |                                           |
+| chartmuseum_request_size_bytes_count       |         |                                                       |                                           |
+| chartmuseum_response_size_bytes            | Summary | {quantile="0.5"}, {quantile="0.9"}, {quantile="0.99"} | The HTTP response sizes in bytes          |
+| chartmuseum_response_size_bytes_sum        |         |                                                       |                                           |
+| chartmuseum_response_size_bytes_count      |         |                                                       |                                           |
+| go_goroutines                              | Gauge   |                                                       | Number of goroutines that currently exist |
 
 
 ## Notes on index.yaml
@@ -531,13 +532,13 @@ You can then use *ChartMuseum* to serve up an internal mirror:
 scripts/mirror_k8s_repos.sh
 chartmuseum --debug --port=8080 --storage="local" --storage-local-rootdir="./mirror"
  ```
- 
+
 ## Original Logo
 
 <sub>**_"Preserve your precious artifacts... in the cloud!"_**<sub>
 
 ![](./logo.png)
-  
+
 ## Subprojects
 
 The following subprojects are maintained by *ChartMuseum*:

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -78,6 +78,7 @@ func cliHandler(c *cli.Context) {
 		LogHealth:              conf.GetBool("loghealth"),
 		Debug:                  conf.GetBool("debug"),
 		EnableAPI:              !conf.GetBool("disableapi"),
+		DisableDelete:          conf.GetBool("disabledelete"),
 		UseStatefiles:          !conf.GetBool("disablestatefiles"),
 		AllowOverwrite:         conf.GetBool("allowoverwrite"),
 		AllowForceOverwrite:    !conf.GetBool("disableforceoverwrite"),

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -46,6 +46,7 @@ type (
 		EnableAPI              bool
 		UseStatefiles          bool
 		AllowOverwrite         bool
+		DisableDelete          bool
 		AllowForceOverwrite    bool
 		EnableMetrics          bool
 		AnonymousGet           bool
@@ -112,6 +113,7 @@ func NewServer(options ServerOptions) (Server, error) {
 		IndexLimit:             options.IndexLimit,
 		GenIndex:               options.GenIndex,
 		EnableAPI:              options.EnableAPI,
+		DisableDelete:          options.DisableDelete,
 		UseStatefiles:          options.UseStatefiles,
 		AllowOverwrite:         options.AllowOverwrite,
 		AllowForceOverwrite:    options.AllowForceOverwrite,

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -41,7 +41,6 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 		{"GET", "/api/:repo/charts/:name/:version", s.getChartVersionRequestHandler, cm_auth.PullAction},
 		{"POST", "/api/:repo/charts", s.postRequestHandler, cm_auth.PushAction},
 		{"POST", "/api/:repo/prov", s.postProvenanceFileRequestHandler, cm_auth.PushAction},
-		{"DELETE", "/api/:repo/charts/:name/:version", s.deleteChartVersionRequestHandler, cm_auth.PushAction},
 	}
 
 	routes = append(routes, serverInfoRoutes...)
@@ -49,6 +48,10 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 
 	if s.APIEnabled {
 		routes = append(routes, chartManipulationRoutes...)
+	}
+
+	if s.APIEnabled && !s.DisableDelete {
+		routes = append(routes, &cm_router.Route{"DELETE", "/api/:repo/charts/:name/:version", s.deleteChartVersionRequestHandler, cm_auth.PushAction})
 	}
 
 	return routes

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -54,6 +54,7 @@ type (
 		AllowOverwrite         bool
 		AllowForceOverwrite    bool
 		APIEnabled             bool
+		DisableDelete          bool
 		UseStatefiles          bool
 		ChartURL               string
 		ChartPostFormFieldName string
@@ -78,6 +79,7 @@ type (
 		AllowOverwrite         bool
 		AllowForceOverwrite    bool
 		EnableAPI              bool
+		DisableDelete          bool
 		UseStatefiles          bool
 	}
 
@@ -120,6 +122,7 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 		AllowOverwrite:         options.AllowOverwrite,
 		AllowForceOverwrite:    options.AllowForceOverwrite,
 		APIEnabled:             options.EnableAPI,
+		DisableDelete:          options.DisableDelete,
 		UseStatefiles:          options.UseStatefiles,
 		Limiter:                make(chan struct{}, options.IndexLimit),
 		Tenants:                map[string]*tenantInternals{},

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -94,6 +94,15 @@ var configVars = map[string]configVar{
 			EnvVar: "DISABLE_API",
 		},
 	},
+	"disabldelete": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "disable-delete",
+			Usage:  "disable DELETE route",
+			EnvVar: "DISABLE_DELETE",
+		},
+	},
 	"disablestatefiles": {
 		Type:    boolType,
 		Default: false,


### PR DESCRIPTION
It may be desirable to limit destructive operations like the DELETE
route.

This change introduces another setting for disabling the destructive
delete route. It is inactive by default (hence the negated bool var
name), so it is backward compatible.

closes #243