### PR TITLE
Add support for building armv7 binaries and conatiners

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,0 +1,7 @@
+FROM arm32v7/alpine:3.9
+
+RUN apk add --no-cache cifs-utils ca-certificates \
+    && adduser -D -u 1000 chartmuseum
+COPY bin/linux/armv7/chartmuseum /chartmuseum
+USER 1000
+ENTRYPOINT ["/chartmuseum"]

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,21 @@ build-linux:
 	go build -v --ldflags="-w -X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
 		-o bin/linux/amd64/chartmuseum cmd/chartmuseum/main.go  # linux
 
+build-armv7: export GOOS=linux
+build-armv7: export GOARCH=arm
+build-armv7: export GOARM=7
+build-armv7: export CGO_ENABLED=0
+build-armv7: export GO111MODULE=on
+build-armv7: export GOPROXY=$(MOD_PROXY_URL)
+build-armv7:
+	go build -v --ldflags="-w -X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
+		-o bin/linux/armv7/chartmuseum cmd/chartmuseum/main.go  # linux
+
+container-armv7: build-armv7
+container-armv7:
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	docker build . -t chartmuseum:v$(VERSION) -f Dockerfile.arm
+
 build-mac: export GOOS=darwin
 build-mac: export GOARCH=amd64
 build-mac: export CGO_ENABLED=0


### PR DESCRIPTION
If you decide to support armv7 builds, this would resolve #263 

I know the other build targets don't have tasks to build containers, but because arm requires an initial step to prepare docker to cross-build, I figured it was a worthy addition.  With this change you can simply run `make container-armv7` and you will get a proper armv7 compatible docker image to do with whatever you want ;)