### PR TITLE
fix ChartVersion parse conflict

### DIFF
--- a/pkg/repo/chart.go
+++ b/pkg/repo/chart.go
@@ -102,20 +102,22 @@ func chartFromContent(content []byte) (*helm_chart.Chart, error) {
 func emptyChartVersionFromPackageFilename(filename string) *helm_repo.ChartVersion {
 	noExt := strings.TrimSuffix(pathutil.Base(filename), fmt.Sprintf(".%s", ChartPackageFileExtension))
 	parts := strings.Split(noExt, "-")
+	lastIndex := len(parts) - 1
 	name := parts[0]
 	version := ""
-	for idx, part := range parts[1:] {
-		if _, err := strconv.Atoi(string(part[0])); err == nil { // see if this part looks like a version (starts w int)
-			version = strings.Join(parts[idx+1:], "-")
+
+	for idx := lastIndex; idx >= 1; idx-- {
+		if _, err := strconv.Atoi(string(parts[idx][0])); err == nil { // see if this part looks like a version (starts w int)
+			version = strings.Join(parts[idx:], "-")
+			name = strings.Join(parts[:idx], "-")
 			break
 		}
-		name = fmt.Sprintf("%s-%s", name, part)
 	}
 	if version == "" { // no parts looked like a real version, just take everything after last hyphen
-		lastIndex := len(parts) - 1
 		name = strings.Join(parts[:lastIndex], "-")
 		version = parts[lastIndex]
 	}
+
 	metadata := &helm_chart.Metadata{Name: name, Version: version}
 	return &helm_repo.ChartVersion{Metadata: metadata}
 }

--- a/pkg/repo/chart_test.go
+++ b/pkg/repo/chart_test.go
@@ -112,6 +112,29 @@ func (suite *ChartTestSuite) TestChartVersionFromStorageObject() {
 	suite.Nil(err)
 	suite.Equal("my-long-hyphenated-chart-name", chartVersion.Name, "chart name as expected")
 	suite.Equal("crapversion", chartVersion.Version, "chart version as expected")
+
+	// Issue #261
+	hyphenDigitalObject := storage.Object{
+		Path:         "mychart-1x-1.0.4.tgz",
+		Content:      []byte{},
+		LastModified: time.Now(),
+	}
+	chartVersion, err = ChartVersionFromStorageObject(hyphenDigitalObject)
+	suite.Nil(err)
+	suite.Equal("mychart-1x", chartVersion.Name, "chart name as expected")
+	suite.Equal("1.0.4", chartVersion.Version, "chart version as expected")
+
+	hyphenDigitalObject.Path = "mychart-1x-1.0.4-rc1.tgz"
+	chartVersion, err = ChartVersionFromStorageObject(hyphenDigitalObject)
+	suite.Nil(err)
+	suite.Equal("mychart-1x", chartVersion.Name, "chart name as expected")
+	suite.Equal("1.0.4-rc1", chartVersion.Version, "chart version as expected")
+
+	hyphenDigitalObject.Path = "mychart-1x-1.0.4-rc1-SNAPSHOT.tgz"
+	chartVersion, err = ChartVersionFromStorageObject(hyphenDigitalObject)
+	suite.Nil(err)
+	suite.Equal("mychart-1x", chartVersion.Name, "chart name as expected")
+	suite.Equal("1.0.4-rc1-SNAPSHOT", chartVersion.Version, "chart version as expected")
 }
 
 func (suite *ChartTestSuite) TestStorageObjectFromChartVersion() {


### PR DESCRIPTION
Parse chart `Version` backwards until a field starting with digit is found.
Fix #261
Signed-off-by: duyanghao <1294057873@qq.com>