### PR TITLE
Mini-Suggestion

### DIFF
--- a/pkg/chartmuseum/router/match.go
+++ b/pkg/chartmuseum/router/match.go
@@ -83,7 +83,6 @@ func match(routes []*Route, method string, url string, contextPath string, depth
 	}
 
 	pathSplit := strings.Split(url, "/")
-	numParts := len(pathSplit)
 
 	if depthdynamic {
 		for _, route := range routes {
@@ -103,7 +102,7 @@ func match(routes []*Route, method string, url string, contextPath string, depth
 		}
 	}
 
-	if numParts >= depth+startIndex {
+	if len(pathSplit) >= depth+startIndex {
 		repoParts := pathSplit[startIndex : depth+startIndex]
 		if len(repoParts) == depth {
 			tryRepoRoutes = true


### PR DESCRIPTION
This commit will remove the assignment of `len(pathSplit)` to a variable.

There is no need for this assignment since it's used only once and the `len(pathSplit)` is self-explanatory when used later on in the conditional.
