### PR TITLE
Fix broken symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><img align="center" src="logo2.png"></p><br/>
 
-*ChartMuseum* is an open-source **[Helm Chart Repository](https://github.com/helm/helm/blob/master/docs/chart_repository.md)** server written in Go (Golang), with support for cloud storage backends, including [Google Cloud Storage](https://cloud.google.com/storage/), [Amazon S3](https://aws.amazon.com/s3/), [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/), [Alibaba Cloud OSS Storage](https://www.alibabacloud.com/product/oss), [Openstack Object Storage](https://developer.openstack.org/api-ref/object-store/), [Oracle Cloud Infrastructure Object Storage](https://cloud.oracle.com/storage), and [Baidu Cloud BOS Storage](https://cloud.baidu.com/product/bos.html).
+*ChartMuseum* is an open-source **[Helm Chart Repository](https://github.com/helm/charts)** server written in Go (Golang), with support for cloud storage backends, including [Google Cloud Storage](https://cloud.google.com/storage/), [Amazon S3](https://aws.amazon.com/s3/), [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/), [Alibaba Cloud OSS Storage](https://www.alibabacloud.com/product/oss), [Openstack Object Storage](https://developer.openstack.org/api-ref/object-store/), [Oracle Cloud Infrastructure Object Storage](https://cloud.oracle.com/storage), and [Baidu Cloud BOS Storage](https://cloud.baidu.com/product/bos.html).
 
 Works as a valid Helm Chart Repository, and also provides an API for uploading charts.
 


### PR DESCRIPTION
I see the link to[ Helm Chart Repository](https://github.com/helm/helm/blob/master/docs/chart_repository.md) is broken.
I have replaced the link to point to charts repo.
P.S: I see the same broken link even in https://chartmuseum.com/ site :).