### PR TITLE
Improve performance when dealing with  thousands of charts

### DIFF
--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -148,9 +148,9 @@ func backendFromConfig(conf *config.Config) storage.Backend {
 
 func localBackendFromConfig(conf *config.Config) storage.Backend {
 	crashIfConfigMissingVars(conf, []string{"storage.local.rootdir"})
-	return storage.Backend(storage.NewLocalFilesystemBackend(
+	return storage.NewLocalFilesystemBackend(
 		conf.GetString("storage.local.rootdir"),
-	))
+	)
 }
 
 func amazonBackendFromConfig(conf *config.Config) storage.Backend {
@@ -159,68 +159,68 @@ func amazonBackendFromConfig(conf *config.Config) storage.Backend {
 		conf.Set("storage.amazon.region", "us-east-1")
 	}
 	crashIfConfigMissingVars(conf, []string{"storage.amazon.bucket", "storage.amazon.region"})
-	return storage.Backend(storage.NewAmazonS3Backend(
+	return storage.NewAmazonS3Backend(
 		conf.GetString("storage.amazon.bucket"),
 		conf.GetString("storage.amazon.prefix"),
 		conf.GetString("storage.amazon.region"),
 		conf.GetString("storage.amazon.endpoint"),
 		conf.GetString("storage.amazon.sse"),
-	))
+	)
 }
 
 func googleBackendFromConfig(conf *config.Config) storage.Backend {
 	crashIfConfigMissingVars(conf, []string{"storage.google.bucket"})
-	return storage.Backend(storage.NewGoogleCSBackend(
+	return storage.NewGoogleCSBackend(
 		conf.GetString("storage.google.bucket"),
 		conf.GetString("storage.google.prefix"),
-	))
+	)
 }
 
 func oracleBackendFromConfig(conf *config.Config) storage.Backend {
 	crashIfConfigMissingVars(conf, []string{"storage.oracle.bucket", "storage.oracle.compartmentid"})
-	return storage.Backend(storage.NewOracleCSBackend(
+	return storage.NewOracleCSBackend(
 		conf.GetString("storage.oracle.bucket"),
 		conf.GetString("storage.oracle.prefix"),
 		conf.GetString("storage.oracle.region"),
 		conf.GetString("storage.oracle.compartmentid"),
-	))
+	)
 }
 
 func microsoftBackendFromConfig(conf *config.Config) storage.Backend {
 	crashIfConfigMissingVars(conf, []string{"storage.microsoft.container"})
-	return storage.Backend(storage.NewMicrosoftBlobBackend(
+	return storage.NewMicrosoftBlobBackend(
 		conf.GetString("storage.microsoft.container"),
 		conf.GetString("storage.microsoft.prefix"),
-	))
+	)
 }
 
 func alibabaBackendFromConfig(conf *config.Config) storage.Backend {
 	crashIfConfigMissingVars(conf, []string{"storage.alibaba.bucket"})
-	return storage.Backend(storage.NewAlibabaCloudOSSBackend(
+	return storage.NewAlibabaCloudOSSBackend(
 		conf.GetString("storage.alibaba.bucket"),
 		conf.GetString("storage.alibaba.prefix"),
 		conf.GetString("storage.alibaba.endpoint"),
 		conf.GetString("storage.alibaba.sse"),
-	))
+	)
 }
 
 func openstackBackendFromConfig(conf *config.Config) storage.Backend {
 	crashIfConfigMissingVars(conf, []string{"storage.openstack.container", "storage.openstack.region"})
-	return storage.Backend(storage.NewOpenstackOSBackend(
+	return storage.NewOpenstackOSBackend(
 		conf.GetString("storage.openstack.container"),
 		conf.GetString("storage.openstack.prefix"),
 		conf.GetString("storage.openstack.region"),
 		conf.GetString("storage.openstack.cacert"),
-	))
+	)
 }
 
 func baiduBackendFromConfig(conf *config.Config) storage.Backend {
 	crashIfConfigMissingVars(conf, []string{"storage.baidu.bucket"})
-	return storage.Backend(storage.NewBaiDuBOSBackend(
+	return storage.NewBaiDuBOSBackend(
 		conf.GetString("storage.baidu.bucket"),
 		conf.GetString("storage.baidu.prefix"),
 		conf.GetString("storage.baidu.endpoint"),
-	))
+	)
 }
 
 func etcdBackendFromConfig(conf *config.Config) storage.Backend {
@@ -228,31 +228,31 @@ func etcdBackendFromConfig(conf *config.Config) storage.Backend {
 		"storage.etcd.certfile",
 		"storage.etcd.keyfile",
 		"storage.etcd.prefix"})
-	return storage.Backend(storage.NewEtcdCSBackend(
+	return storage.NewEtcdCSBackend(
 		conf.GetString("storage.etcd.endpoint"),
 		conf.GetString("storage.etcd.cafile"),
 		conf.GetString("storage.etcd.certfile"),
 		conf.GetString("storage.etcd.keyfile"),
 		conf.GetString("storage.etcd.prefix"),
-	))
+	)
 }
 
 func tencentBackendFromConfig(conf *config.Config) storage.Backend {
 	crashIfConfigMissingVars(conf, []string{"storage.tencent.bucket"})
-	return storage.Backend(storage.NewTencentCloudCOSBackend(
+	return storage.NewTencentCloudCOSBackend(
 		conf.GetString("storage.tencent.bucket"),
 		conf.GetString("storage.tencent.prefix"),
 		conf.GetString("storage.tencent.endpoint"),
-	))
+	)
 }
 
 func neteaseBackendFromConfig(conf *config.Config) storage.Backend {
 	crashIfConfigMissingVars(conf, []string{"storage.netease.bucket"})
-	return storage.Backend(storage.NewNeteaseNOSBackend(
+	return storage.NewNeteaseNOSBackend(
 		conf.GetString("storage.netease.bucket"),
 		conf.GetString("storage.netease.prefix"),
 		conf.GetString("storage.netease.endpoint"),
-	))
+	)
 }
 
 func storeFromConfig(conf *config.Config) cache.Store {
@@ -283,7 +283,7 @@ func redisCacheFromConfig(conf *config.Config) cache.Store {
 }
 
 func crashIfConfigMissingVars(conf *config.Config, vars []string) {
-	missing := []string{}
+	var missing []string
 	for _, v := range vars {
 		if conf.GetString(v) == "" {
 			flag := config.GetCLIFlagFromVarName(v)

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -18,9 +18,11 @@ package main
 
 import (
 	"fmt"
+	"helm.sh/chartmuseum/pkg/chartmuseum/server/multitenant"
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/chartmuseum/storage"
 	"helm.sh/chartmuseum/pkg/cache"
@@ -107,6 +109,17 @@ func cliHandler(c *cli.Context) {
 		crash(err)
 	}
 
+	go func() {
+		t := time.NewTicker(time.Minute * 5)
+		for _ = range t.C {
+			server.(*multitenant.MultiTenantServer).RebuildIndex()
+		}
+	}()
+
+	go func() {
+		multitenant.InitUpdateObjectChan()
+		server.(*multitenant.MultiTenantServer).Consumer()
+	}()
 	server.Listen(conf.GetInt("port"))
 }
 

--- a/pkg/chartmuseum/server/multitenant/update_cache.go
+++ b/pkg/chartmuseum/server/multitenant/update_cache.go
@@ -1,0 +1,159 @@
+package multitenant
+
+import (
+	cm_storage "github.com/chartmuseum/storage"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	cm_logger "helm.sh/chartmuseum/pkg/chartmuseum/logger"
+	"helm.sh/helm/v3/pkg/repo"
+)
+
+type (
+	updateObject struct {
+		RepoName     string             `json:"repo_name"`
+		OpType       OperationType      `json:"operation_type"`
+		ChartVersion *repo.ChartVersion `json:"chart_version"`
+	}
+)
+type OperationType int
+
+const (
+	UpdateChart OperationType = 0
+	AddChart    OperationType = 1
+	DeleteChart OperationType = 2
+)
+
+var (
+	updateObjectChan chan updateObject
+)
+
+func InitUpdateObjectChan() {
+	updateObjectChan = make(chan updateObject, 100)
+	return
+}
+
+func (server *MultiTenantServer) Producer(repo string, operationType OperationType, chart *repo.ChartVersion) {
+	uo := updateObject{
+		RepoName:     repo,
+		OpType:       operationType,
+		ChartVersion: chart,
+	}
+
+	updateObjectChan <- uo
+	log := server.Logger.ContextLoggingFn(&gin.Context{})
+	log(cm_logger.InfoLevel, "send update", zap.Any("object", uo))
+}
+
+func (server *MultiTenantServer) Consumer() {
+	server.Router.Logger.Info("start consumer")
+	for {
+		log := server.Logger.ContextLoggingFn(&gin.Context{})
+		uo := <-updateObjectChan
+		repo := uo.RepoName
+		log(cm_logger.InfoLevel, "receive update", zap.String("repo", repo), zap.Any("uo", uo))
+		tenant := server.Tenants[uo.RepoName]
+		tenant.RegenerationLock.Lock()
+
+		entry, err := server.initCacheEntry(log, repo)
+		if err != nil {
+			log(cm_logger.ErrorLevel, "initCacheEntry fail", zap.Error(err), zap.String("repo", repo))
+			continue
+		}
+
+		index := entry.RepoIndex
+		switch uo.OpType {
+		case UpdateChart:
+			index.UpdateEntry(uo.ChartVersion)
+		case AddChart:
+			index.AddEntry(uo.ChartVersion)
+		case DeleteChart:
+			index.RemoveEntry(uo.ChartVersion)
+		default:
+			log(cm_logger.ErrorLevel, "invalid operation type", zap.String("repo", repo),
+				"operation_type", uo.OpType)
+			continue
+		}
+
+		err = index.Regenerate()
+		if err != nil {
+			log(cm_logger.ErrorLevel, "regenerate fail", zap.Error(err), zap.String("repo", repo))
+			continue
+		}
+		entry.RepoIndex = index
+
+		err = server.saveCacheEntry(log, entry)
+		if err != nil {
+			log(cm_logger.ErrorLevel, "saveCacheEntry fail", zap.Error(err), zap.String("repo", repo))
+			continue
+		}
+
+		if server.UseStatefiles {
+			// Dont wait, save index-cache.yaml to storage in the background.
+			// It is not crucial if this does not succeed, we will just log any errors
+			go server.saveStatefile(log, uo.RepoName, entry.RepoIndex.Raw)
+		}
+
+		tenant.RegenerationLock.Unlock()
+		log(cm_logger.InfoLevel, "success update", zap.String("repo", repo), zap.Any("uo", uo))
+	}
+}
+
+
+func (server *MultiTenantServer) RebuildIndex() {
+	for repo, _ := range server.Tenants {
+		go func(repo string) {
+			log := server.Logger.ContextLoggingFn(&gin.Context{})
+			log(cm_logger.InfoLevel, "begin to rebuild index", zap.String("repo", repo))
+			entry, err := server.initCacheEntry(log, repo)
+			if err != nil {
+				errStr := err.Error()
+				log(cm_logger.ErrorLevel, errStr,
+					"repo", repo,
+				)
+				return
+			}
+
+			fo := <-server.getChartList(log, repo)
+
+			if fo.err != nil {
+				errStr := fo.err.Error()
+				log(cm_logger.ErrorLevel, errStr,
+					"repo", repo,
+				)
+				return
+			}
+
+			objects := server.getRepoObjectSlice(entry)
+			diff := cm_storage.GetObjectSliceDiff(objects, fo.objects, server.TimestampTolerance)
+
+			// return fast if no changes
+			if !diff.Change {
+				log(cm_logger.DebugLevel, "No change detected between cache and storage",
+					"repo", repo,
+				)
+				return
+			}
+
+			log(cm_logger.DebugLevel, "Change detected between cache and storage",
+				"repo", repo,
+			)
+
+			ir := <-server.regenerateRepositoryIndex(log, entry, diff)
+			if ir.err != nil {
+				errStr := ir.err.Error()
+				log(cm_logger.ErrorLevel, errStr,
+					"repo", repo,
+				)
+				return
+			}
+			entry.RepoIndex = ir.index
+
+			if server.UseStatefiles {
+				// Dont wait, save index-cache.yaml to storage in the background.
+				// It is not crucial if this does not succeed, we will just log any errors
+				go server.saveStatefile(log, repo, ir.index.Raw)
+			}
+
+		}(repo)
+	}
+}


### PR DESCRIPTION
## Summary

As we have disscsused in the [issue](#332),  we need to improve the performance when  dealing with  thousands of charts.  Therefor, we made some changes as we proposed before. 

##  Changes

- Always read from cache in function getIndexFile() without traversing the files on the disk. If cache is missing, rebuild it
- Delta update the cache in all the WRITE requests (e.g. POST /api/charts or DELETE /api/charts/<name>/<version>)
- Delta update the cache every 5min (in case the files on the disk are manually manipulated)


fixes #332