### PR TITLE
Register aliases for config keys that don't match the advertised schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,19 +127,24 @@ All command-line options can be specified as environment variables, which are de
 For example, the env var `STORAGE_AMAZON_BUCKET` can be used in place of `--storage-amazon-bucket`.
 
 ##### Using config yaml file example
-When using a yaml file instead of the command line， Convert the `-` of the parameter in the command to `.`.
-Note that `--storage` is converted to `storage.backend`
+When using a yaml file instead of the command line, convert the `-` of the parameter in the command to `.`.
+There are some exceptions of this rule:
+* `--cache` converts to `cache.backend`
+* `--storage` converts to `storage.backend`
+* `--depth-dynamic` converts to `depthdynamic`
+
 ```yaml
 debug: true
 port: 8080
 storage.backend: local
 storage.local.rootdir: <storage_path>
-bearerauth: 1
-authrealm: <authorization server url>
-authservice: <authorization server service name>
-authcertpath: <path to authorization server public pem file> 
+bearer.auth: 1
+auth:
+  realm: <authorization server url>
+  service: <authorization server service name>
+  cert:
+    path: <path to authorization server public pem file>
 depth: 2
-
 ```
 
 #### Using with Amazon S3 or Compatible services like Minio or DigitalOcean.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,12 +41,17 @@ func NewConfig() *Config {
 	}
 	conf.SetConfigType("yaml")
 	conf.setDefaults()
+	conf.setAliases()
 	return conf
 }
 
 // GetCLIFlagFromVarName returns the name of the CLI flag associated with a config var
 func GetCLIFlagFromVarName(name string) string {
 	var val string
+	realKey, ok := aliasConfigVars[name]
+	if ok {
+		name = realKey
+	}
 	if configVar, ok := configVars[name]; ok {
 		if flag := configVar.CLIFlag; flag != nil {
 			val = flag.GetName()
@@ -106,5 +111,11 @@ func (conf *Config) readConfigFileFromCLIContext(c *cli.Context) error {
 func (conf *Config) setDefaults() {
 	for key, configVar := range configVars {
 		conf.SetDefault(key, configVar.Default)
+	}
+}
+
+func (conf *Config) setAliases() {
+	for alias, key := range aliasConfigVars {
+		conf.RegisterAlias(alias, key)
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -62,6 +62,7 @@ func (suite *ConfigTestSuite) TearDownSuite() {
 
 func (suite *ConfigTestSuite) TestGetCLIFlagFromVarName() {
 	suite.Equal("basic-auth-user", GetCLIFlagFromVarName("basicauth.user"))
+	suite.Equal("basic-auth-user", GetCLIFlagFromVarName("basic.auth.user"))
 	suite.Equal("", GetCLIFlagFromVarName("blah.blah.blah"))
 }
 
@@ -77,6 +78,7 @@ func (suite *ConfigTestSuite) TestUpdateFromCLIContext() {
 	err = conf.UpdateFromCLIContext(c)
 	suite.Nil(err)
 	suite.Equal("", conf.GetString("charturl"))
+	suite.Equal("", conf.GetString("chart.url"))
 	suite.Equal(8080, conf.GetInt("port"))
 	suite.Equal(false, conf.GetBool("debug"))
 
@@ -90,6 +92,7 @@ func (suite *ConfigTestSuite) TestUpdateFromCLIContext() {
 	conf.UpdateFromCLIContext(c)
 	suite.Nil(err)
 	suite.Equal("https://fakesite.com", conf.GetString("charturl"))
+	suite.Equal("https://fakesite.com", conf.GetString("chart.url"))
 	suite.Equal(8081, conf.GetInt("port"))
 	suite.Equal(true, conf.GetBool("debug"))
 
@@ -117,7 +120,9 @@ func (suite *ConfigTestSuite) TestUpdateFromCLIContext() {
 	err = conf.UpdateFromCLIContext(c)
 	suite.Nil(err)
 	suite.Equal("myuser", conf.GetString("basicauth.user"))
+	suite.Equal("myuser", conf.GetString("basic.auth.user"))
 	suite.Equal("mypass", conf.GetString("basicauth.pass"))
+	suite.Equal("mypass", conf.GetString("basic.auth.pass"))
 
 	// valid config file and populated context, context vars should override config file
 	conf = NewConfig()
@@ -128,7 +133,9 @@ func (suite *ConfigTestSuite) TestUpdateFromCLIContext() {
 	err = conf.UpdateFromCLIContext(c)
 	suite.Nil(err)
 	suite.Equal("otherdude", conf.GetString("basicauth.user"))
+	suite.Equal("otherdude", conf.GetString("basic.auth.user"))
 	suite.Equal("mypass", conf.GetString("basicauth.pass"))
+	suite.Equal("mypass", conf.GetString("basic.auth.pass"))
 }
 
 func getNewContext() *cli.Context {

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -741,6 +741,40 @@ var configVars = map[string]configVar{
 	},
 }
 
+// aliasConfigVars is used to register aliases for all config keys that don't match the
+// advertised schema
+var aliasConfigVars = map[string]string{
+	"allow.overwrite":             "allowoverwrite",
+	"auth.anonymous.get":          "authanonymousget",
+	"auth.cert.path":              "authcertpath",
+	"auth.realm":                  "authrealm",
+	"auth.service":                "authservice",
+	"basic.auth.pass":             "basicauth.pass",
+	"basic.auth.user":             "basicauth.user",
+	"bearer.auth":                 "bearerauth",
+	"chart.post.form.field.name":  "chartpostformfieldname",
+	"chart.url":                   "charturl",
+	"context.path":                "contextpath",
+	"disable.delete":              "disabledelete",
+	"disable.api":                 "disableapi",
+	"disable.force.overwrite":     "disableforceoverwrite",
+	"disable.metrics":             "disablemetrics",
+	"disable.statefiles":          "disablestatefiles",
+	"enforce.semver2":             "enforce-semver2",
+	"gen.index":                   "genindex",
+	"index.limit":                 "indexlimit",
+	"log.health":                  "loghealth",
+	"log.json":                    "logjson",
+	"log.latency.integer":         "loglatencyinteger",
+	"max.storage.objects":         "maxstorageobjects",
+	"max.upload.size":             "maxuploadsize",
+	"prov.post.form.field.name":   "provpostformfieldname",
+	"read.timeout":                "readtimeout",
+	"storage.timestamp.tolerance": "storage.timestamptolerance",
+	"tls.ca.cert":                 "tls.cacert",
+	"write.timeout":               "writetimeout",
+}
+
 func populateCLIFlags() {
 	CLIFlags = []cli.Flag{
 		cli.StringFlag{

--- a/pkg/config/vars_test.go
+++ b/pkg/config/vars_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	// "strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// func TestConfigVarNames(t *testing.T) {
+// 	for k, v := range configVars {
+// 		// TODO cache.store can't match schema
+// 		// TODO depthdynamic can't match schema
+// 		// TODO storage.backend can't match schema
+// 		if k == "cache.store" || k == "depthdynamic" || k == "storage.backend" {
+// 			continue
+// 		}
+// 		should := strings.ReplaceAll(v.CLIFlag.GetName(), "-", ".")
+// 		assert.Equal(t, should, k, "configVars key should be cli flag, dahes replaced with dots")
+// 	}
+// }
+
+func TestCompatConfigVars(t *testing.T) {
+	for alias, key := range aliasConfigVars {
+		_, ok := configVars[key]
+		assert.True(t, ok, "alias \"%s\" has bad reference: \"%s\"", alias, key)
+	}
+}


### PR DESCRIPTION
This tries to clean up the situation an bit so that one can write
working configuration files without looking into the code.

I've added a disabled test to check for "invalid" config keys but that
would need renaming of the keys leading to incompatibility with current
contig files on user installations.

It would be nice to have a migration path, though.

Fixes: #308