### PR TITLE
Allow to bind chartmuseum to a specific interface

### DIFF
--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -100,6 +100,7 @@ func cliHandler(c *cli.Context) {
 		WriteTimeout:           conf.GetInt("writetimeout"),
 		ReadTimeout:            conf.GetInt("readtimeout"),
 		EnforceSemver2:         conf.GetBool("enforce-semver2"),
+		Host:                   conf.GetString("listen.host"),
 	}
 
 	server, err := newServer(options)
@@ -107,7 +108,7 @@ func cliHandler(c *cli.Context) {
 		crash(err)
 	}
 
-	server.Listen(conf.GetString("listen.host"), conf.GetInt("port"))
+	server.Listen(conf.GetInt("port"))
 }
 
 func backendFromConfig(conf *config.Config) storage.Backend {

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -107,7 +107,7 @@ func cliHandler(c *cli.Context) {
 		crash(err)
 	}
 
-	server.Listen(conf.GetInt("port"))
+	server.Listen(conf.GetString("listen.host"), conf.GetInt("port"))
 }
 
 func backendFromConfig(conf *config.Config) storage.Backend {

--- a/pkg/chartmuseum/router/router.go
+++ b/pkg/chartmuseum/router/router.go
@@ -49,6 +49,7 @@ type (
 		CORSAllowOrigin string
 		ReadTimeout     time.Duration
 		WriteTimeout    time.Duration
+		Host            string
 	}
 
 	// RouterOptions are options for constructing a Router
@@ -75,6 +76,7 @@ type (
 		ReadTimeout       int
 		WriteTimeout      int
 		CORSAllowOrigin   string
+		Host              string
 	}
 
 	// Route represents an application route
@@ -113,6 +115,7 @@ func NewRouter(options RouterOptions) *Router {
 		CORSAllowOrigin: options.CORSAllowOrigin,
 		ReadTimeout:     time.Duration(options.ReadTimeout) * time.Second,
 		WriteTimeout:    time.Duration(options.WriteTimeout) * time.Second,
+		Host:            options.Host,
 	}
 
 	var err error
@@ -163,13 +166,13 @@ func NewRouter(options RouterOptions) *Router {
 	return router
 }
 
-func (router *Router) Start(host string, port int) {
+func (router *Router) Start(port int) {
 	router.Logger.Infow("Starting ChartMuseum",
-		"host", host, "port", port,
+		"host", router.Host, "port", port,
 	)
 
 	server := http.Server{
-		Addr:         fmt.Sprintf("%s:%d", host, port),
+		Addr:         fmt.Sprintf("%s:%d", router.Host, port),
 		Handler:      router,
 		ReadTimeout:  router.ReadTimeout,
 		WriteTimeout: router.WriteTimeout,

--- a/pkg/chartmuseum/router/router.go
+++ b/pkg/chartmuseum/router/router.go
@@ -163,13 +163,13 @@ func NewRouter(options RouterOptions) *Router {
 	return router
 }
 
-func (router *Router) Start(port int) {
+func (router *Router) Start(host string, port int) {
 	router.Logger.Infow("Starting ChartMuseum",
-		"port", port,
+		"host", host, "port", port,
 	)
 
 	server := http.Server{
-		Addr:         fmt.Sprintf(":%d", port),
+		Addr:         fmt.Sprintf("%s:%d", host, port),
 		Handler:      router,
 		ReadTimeout:  router.ReadTimeout,
 		WriteTimeout: router.WriteTimeout,

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -73,7 +73,7 @@ type (
 
 	// Server is a generic interface for web servers
 	Server interface {
-		Listen(port int)
+		Listen(host string, port int)
 	}
 )
 

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -69,11 +69,12 @@ type (
 		// EnforceSemver2 represents if the museum server always accept the Chart with [valid semantic version 2](https://semver.org/)
 		// More refers to : https://github.com/helm/chartmuseum/issues/320
 		EnforceSemver2 bool
+		Host           string
 	}
 
 	// Server is a generic interface for web servers
 	Server interface {
-		Listen(host string, port int)
+		Listen(port int)
 	}
 )
 
@@ -114,6 +115,7 @@ func NewServer(options ServerOptions) (Server, error) {
 		CORSAllowOrigin:   options.CORSAllowOrigin,
 		ReadTimeout:       options.ReadTimeout,
 		WriteTimeout:      options.WriteTimeout,
+		Host:              options.Host,
 	})
 
 	server, err := mt.NewMultiTenantServer(mt.MultiTenantServerOptions{

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -147,8 +147,8 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 }
 
 // Listen starts the router on a given port
-func (server *MultiTenantServer) Listen(host string, port int) {
-	server.Router.Start(host, port)
+func (server *MultiTenantServer) Listen(port int) {
+	server.Router.Start(port)
 }
 
 func (server *MultiTenantServer) genIndex() {

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -147,8 +147,8 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 }
 
 // Listen starts the router on a given port
-func (server *MultiTenantServer) Listen(port int) {
-	server.Router.Start(port)
+func (server *MultiTenantServer) Listen(host string, port int) {
+	server.Router.Start(host, port)
 }
 
 func (server *MultiTenantServer) genIndex() {

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -739,6 +739,15 @@ var configVars = map[string]configVar{
 			EnvVar: "ENFORCE_SEMVER2",
 		},
 	},
+	"listen.host": {
+		Type:    stringType,
+		Default: "0.0.0.0",
+		CLIFlag: cli.StringFlag{
+			Name:   "listen-host",
+			Usage:  "specifies the host to listen on",
+			EnvVar: "LISTEN_HOST",
+		},
+	},
 }
 
 func populateCLIFlags() {


### PR DESCRIPTION
The new config option "listen.host" ("--listen-host", "LISTEN_HOST") may
be used to bind  chartmuseum to a specific interface rather than 0.0.0.0.

Default is 0.0.0.0 to stick with current behaviour.

Fixes #255