### PR TITLE
Add support for Swift V1 Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,20 @@ chartmuseum --debug --port=8080 \
   --storage-openstack-region="myregion"
 ```
 
+For Swift V1 Auth you must set the following env vars:
+- `ST_AUTH`
+- `ST_USER`
+- `ST_KEY`
+
+```bash
+chartmuseum --debug --port=8080 \
+  --storage="openstack" \
+  --storage-openstack-auth="v1" \
+  --storage-openstack-container="mycontainer" \
+  --storage-openstack-prefix=""
+```
+
+
 #### Using with Oracle Cloud Infrastructure Object Storage
 
 Make sure your environment is properly setup to access `my-ocs-bucket`.

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -205,13 +205,27 @@ func alibabaBackendFromConfig(conf *config.Config) storage.Backend {
 }
 
 func openstackBackendFromConfig(conf *config.Config) storage.Backend {
-	crashIfConfigMissingVars(conf, []string{"storage.openstack.container", "storage.openstack.region"})
-	return storage.NewOpenstackOSBackend(
-		conf.GetString("storage.openstack.container"),
-		conf.GetString("storage.openstack.prefix"),
-		conf.GetString("storage.openstack.region"),
-		conf.GetString("storage.openstack.cacert"),
-	)
+	var backend storage.Backend
+	switch conf.GetString("storage.openstack.auth") {
+	case "v1":
+		crashIfConfigMissingVars(conf, []string{"storage.openstack.container"})
+		backend = storage.NewOpenstackOSBackendV1Auth(
+			conf.GetString("storage.openstack.container"),
+			conf.GetString("storage.openstack.prefix"),
+			conf.GetString("storage.openstack.cacert"),
+		)
+	case "auto":
+		crashIfConfigMissingVars(conf, []string{"storage.openstack.container", "storage.openstack.region"})
+		backend = storage.NewOpenstackOSBackend(
+			conf.GetString("storage.openstack.container"),
+			conf.GetString("storage.openstack.prefix"),
+			conf.GetString("storage.openstack.region"),
+			conf.GetString("storage.openstack.cacert"),
+		)
+	default:
+		crash("Unsupported OpenStack auth protocol: ", conf.GetString("storage.openstack.auth"))
+	}
+	return backend
 }
 
 func baiduBackendFromConfig(conf *config.Config) storage.Backend {

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -485,6 +485,15 @@ var configVars = map[string]configVar{
 			EnvVar: "STORAGE_OPENSTACK_CACERT",
 		},
 	},
+	"storage.openstack.auth": {
+		Type:    stringType,
+		Default: "auto",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-openstack-auth",
+			Usage:  "the OpenStack auth protocol to use. Set \"v1\" for v1 or \"auto\" for v2 and v3",
+			EnvVar: "STORAGE_OPENSTACK_AUTH",
+		},
+	},
 	"storage.baidu.prefix": {
 		Type:    stringType,
 		Default: "",


### PR DESCRIPTION
This adds support for Swift V1 Auth sharing all of the config options with openstack. I've added a new option (--storage-openstack-auth=v1) to switch to V1 Auth.

This depends on https://github.com/chartmuseum/storage/pull/45

Signed-off-by: jayme-github <jayme-github@users.noreply.github.com>