### PR TITLE
Multi architecture container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,10 @@
+# Don't bring in anything into the build context
+
 *
-!bin/**
-vendor
+
+# Bring in our source code and dependency listings
+
+!go.mod
+!go.sum
+!cmd/**
+!pkg/**

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,72 @@
+name: Deploy multi-architecture Docker images for chartmuseum with buildx
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # everyday at midnight UTC
+  pull_request:
+    branches: master
+  push:
+    branches: master
+    tags:
+      - v*
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Prepare
+        id: prepare
+        run: |
+          DOCKER_IMAGE=chartmuseum/chartmuseum
+          DOCKER_PLATFORMS=linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386
+          VERSION=edge
+
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
+
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            VERSION=nightly
+          fi
+
+          TAGS="--tag ${DOCKER_IMAGE}:${VERSION} --tag ${DOCKER_IMAGE}:latest"
+
+          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} \
+            --build-arg revision=$(git rev-parse --short HEAD) \
+            ${TAGS} .
+      -
+        name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+      -
+        name: Docker Buildx (build)
+        run: |
+          docker buildx build --no-cache --pull --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Docker Login
+        if: success() && github.event_name != 'pull_request'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      -
+        name: Docker Buildx (push)
+        if: success() && github.event_name != 'pull_request'
+        run: |
+          docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Docker Check Manifest
+        if: always() && github.event_name != 'pull_request'
+        run: |
+          docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+      -
+        name: Clear
+        if: always() && github.event_name != 'pull_request'
+        run: |
+          rm -f ${HOME}/.docker/config.json

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,7 +1,0 @@
-FROM arm32v7/alpine:3.9
-
-RUN apk add --no-cache cifs-utils ca-certificates \
-    && adduser -D -u 1000 chartmuseum
-COPY bin/linux/armv7/chartmuseum /chartmuseum
-USER 1000
-ENTRYPOINT ["/chartmuseum"]

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,6 @@ build-armv7:
 	go build -v --ldflags="-w -X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
 		-o bin/linux/armv7/chartmuseum cmd/chartmuseum/main.go  # linux
 
-container-armv7: build-armv7
-container-armv7:
-	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-	docker build . -t chartmuseum:v$(VERSION) -f Dockerfile.arm
-
 build-mac: export GOOS=darwin
 build-mac: export GOARCH=amd64
 build-mac: export CGO_ENABLED=0


### PR DESCRIPTION
This PR would allow for a multi-architecture container image to be built and (sometimes) pushed to Docker hub when necessary.

In order for this to work, 2 things were done:

* Rewrite the Dockerfile to built the `chartmuseum` executable inside a Docker container in a portable way.
* Add a GitHub action to leverage [`docker buildx`](https://docs.docker.com/buildx/working-with-buildx/) and "cross-build" the container image for multiple architectures.

In order for this to work, 2 secrets need to be added to the `helm/chartmuseum` GitHub repository.

The first one called DOCKER_USERNAME should be the Docker hub username for the "chartmuseum" account.

The second one called DOCKER_PASSWORD should be an access token generated on Docker hub like explained [here](https://docs.docker.com/docker-hub/access-tokens/).

The images will be built for the following architectures:

* amd64 (x86_64)
* i386 (x86)
* armv8 (aarch64/arm64)
* armv7
* armv6

The images will be built (and sometimes pushed) in the following circumstances:

* on pull requests (just built)
* on tag pushes when the tag matches: vX.Y.Z (built and pushed as `chartmuseum/chartmuseum:X.Y.Z` and `chartmuseum/chartmuseum:latest`)
* on pushes to master (built and pushed as `chartmuseum/chartmuseum:edge` and `chartmuseum/chartmuseum:latest`)
* every night at midnight UTC to pull in updates in the dependencies, the `golang` image and the `alpine` image (built  and pushed as `chartmuseum/chartmuseum:nightly` and `chartmuseum/chartmuseum:latest`)

In order to test this would work, I have built and deployed the multi-architecture image to my own Docker hub account and tested it on the armv8 architecture.

If someone wants to test any other architecture, the image can be found [here](https://hub.docker.com/r/zuh0/chartmuseum).

This PR resolves #349 .