### PR TITLE
[WIP]pkg/repo: changes the index entries map key from chart name to object path

### DIFF
--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -17,6 +17,8 @@ limitations under the License.
 package repo
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -80,13 +82,24 @@ func (index *Index) Regenerate() error {
 
 // RemoveEntry removes a chart version from index
 func (index *Index) RemoveEntry(chartVersion *helm_repo.ChartVersion) {
-	if entries, ok := index.Entries[chartVersion.Name]; ok {
+	path := chartObjectPath(chartVersion)
+	index.remove(path)
+}
+
+// RemoveEntryWithObjectPath removes chart version from index (with the chart object path)
+func (index *Index) RemoveEntryWithObjectPath(path string) {
+	index.remove(path)
+}
+
+func (index *Index) remove(path string) {
+	if entries, ok := index.Entries[path]; ok {
 		for i, cv := range entries {
-			if cv.Version == chartVersion.Version {
-				index.Entries[chartVersion.Name] = append(entries[:i],
+			// version is always located at the tail of the path
+			if strings.HasSuffix(path, cv.Version) {
+				index.Entries[path] = append(entries[:i],
 					entries[i+1:]...)
-				if len(index.Entries[chartVersion.Name]) == 0 {
-					delete(index.Entries, chartVersion.Name)
+				if len(index.Entries[path]) == 0 {
+					delete(index.Entries, path)
 				}
 				break
 			}
@@ -96,16 +109,17 @@ func (index *Index) RemoveEntry(chartVersion *helm_repo.ChartVersion) {
 
 // AddEntry adds a chart version to index
 func (index *Index) AddEntry(chartVersion *helm_repo.ChartVersion) {
-	if _, ok := index.Entries[chartVersion.Name]; !ok {
-		index.Entries[chartVersion.Name] = helm_repo.ChartVersions{}
+	path := chartObjectPath(chartVersion)
+	if _, ok := index.Entries[path]; !ok {
+		index.Entries[path] = helm_repo.ChartVersions{}
 	}
 	index.setChartURL(chartVersion)
-	index.Entries[chartVersion.Name] = append(index.Entries[chartVersion.Name], chartVersion)
+	index.Entries[path] = append(index.Entries[path], chartVersion)
 }
 
 // HasEntry checks if index has already an entry
 func (index *Index) HasEntry(chartVersion *helm_repo.ChartVersion) bool {
-	if entries, ok := index.Entries[chartVersion.Name]; ok {
+	if entries, ok := index.Entries[chartObjectPath(chartVersion)]; ok {
 		for _, cv := range entries {
 			if cv.Version == chartVersion.Version {
 				return true
@@ -117,7 +131,7 @@ func (index *Index) HasEntry(chartVersion *helm_repo.ChartVersion) bool {
 
 // UpdateEntry updates a chart version in index
 func (index *Index) UpdateEntry(chartVersion *helm_repo.ChartVersion) {
-	if entries, ok := index.Entries[chartVersion.Name]; ok {
+	if entries, ok := index.Entries[chartObjectPath(chartVersion)]; ok {
 		for i, cv := range entries {
 			if cv.Version == chartVersion.Version {
 				index.setChartURL(chartVersion)
@@ -142,4 +156,18 @@ func (index *Index) updateMetrics() {
 	}
 	chartTotalGaugeVec.WithLabelValues(index.RepoName).Set(float64(len(index.Entries)))
 	chartVersionTotalGaugeVec.WithLabelValues(index.RepoName).Set(float64(nChartVersions))
+}
+
+// chartObjectPath will be used as the key to access the index entries.
+// We can not easily use the chartVersion's Name as the key
+// because we can not parse the chart filename with the standard chartName and chartVersion properly(so much PRs and FIXs to the current parse confliction)
+// With no semantic version chart , it even be worse to manage the chart cache (Remove).
+// After we change the entries key from ChartName to ChartPath ,we can easily delete the cache with the object.Path
+// and no need to parse the object.Path to ChartName and ChartVersion with lots of effort.
+func chartObjectPath(cv *helm_repo.ChartVersion) string {
+	return objectPath(cv.Name, cv.Version)
+}
+
+func objectPath(name, version string) string {
+	return fmt.Sprintf("%s-%s", name, version)
 }


### PR DESCRIPTION
Just a proposal:

If we can replace the index entries map key with object path , it will let us access the cache more convenient:

* No chart filename parsing
* Make the Object structure  more close to the ChartVersion structure 

But I wonder if these changes break the Helm spec about repo index entry itself ?