### PR TITLE
Add repos endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ Powered by some great Go technology:
 - `GET /charts/mychart-0.1.0.tgz` - retrieved when you run `helm install chartmuseum/mychart`
 - `GET /charts/mychart-0.1.0.tgz.prov` - retrieved when you run `helm install` with the `--verify` flag
 
-### Repository Manipulation
-- `GET /api/repos` - list chart repos (only works with multitenancy enabled).
-- `GET /api/<fragment>/repos` - list sub-repos within a repository (only works with multitenancy enabled).
-
 ### Chart Manipulation
 - `POST /api/charts` - upload a new chart version
 - `POST /api/prov` - upload a new provenance file
@@ -42,6 +38,8 @@ Powered by some great Go technology:
 - `GET /api/charts/<name>/<version>` - describe a chart version
 - `HEAD /api/charts/<name>` - check if chart exists (any versions)
 - `HEAD /api/charts/<name>/<version>` - check if chart version exists
+- `GET /api/repos` - list chart repos (only works with multitenancy enabled).
+- `GET /api/<fragment>/repos` - list sub-repos within a repository (only works with multitenancy enabled).
 
 ### Server Info
 - `GET /` - HTML welcome page

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Powered by some great Go technology:
 - `GET /charts/mychart-0.1.0.tgz` - retrieved when you run `helm install chartmuseum/mychart`
 - `GET /charts/mychart-0.1.0.tgz.prov` - retrieved when you run `helm install` with the `--verify` flag
 
+### Repository Manipulation
+- `GET /api/repos` - list chart repos (only works with multitenancy enabled).
+- `GET /api/<fragment>/repos` - list sub-repos within a repository (only works with multitenancy enabled).
+
 ### Chart Manipulation
 - `POST /api/charts` - upload a new chart version
 - `POST /api/prov` - upload a new provenance file

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 replace (
 	github.com/NetEase-Object-Storage/nos-golang-sdk => github.com/karuppiah7890/nos-golang-sdk v0.0.0-20191116042345-0792ba35abcc
 	go.etcd.io/etcd => github.com/eddycjy/etcd v0.5.0-alpha.5.0.20200218102753-4258cdd2efdf
+	github.com/chartmuseum/storage => github.com/farmersedgeinc/storage v0.9.1-0.20200810211930-42f6c50507a1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5I
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
+github.com/farmersedgeinc/storage v0.9.1-0.20200810211930-42f6c50507a1 h1:cKye6v7a/4N4D71POTDK9jrmzlMASdBT4Ee0+UhLNg8=
+github.com/farmersedgeinc/storage v0.9.1-0.20200810211930-42f6c50507a1/go.mod h1:rEOwJVPHU569BC22tUhl6g64sYPxFzZKrxxzjz+zvWQ=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/pkg/chartmuseum/router/match.go
+++ b/pkg/chartmuseum/router/match.go
@@ -84,27 +84,31 @@ func match(routes []*Route, method string, url string, contextPath string, depth
 		if match, pathComponents, depthCandidate := comparePaths(
 			requestPathComponents,
 			routePathComponents,
-			":repo",
-		); match && (depthCandidate == -1 || depthdynamic || depthCandidate == depth) {
-			route = routeCandidate
-			requestPathComponents = pathComponents
+			":repofragment",
+		); match {
+			if depthdynamic || depthCandidate < depth {
+				route = routeCandidate
+				requestPathComponents = pathComponents
+			}
 			break
 		}
 
 		if match, pathComponents, depthCandidate := comparePaths(
 			requestPathComponents,
 			routePathComponents,
-			":repofragment",
-		); match && (depthdynamic || depthCandidate < depth ){
-			route = routeCandidate
-			requestPathComponents = pathComponents
+			":repo",
+		); match {
+			if depthCandidate == -1 || depthdynamic || depthCandidate == depth {
+				route = routeCandidate
+				requestPathComponents = pathComponents
+			}
 			break
 		}
 	}
 	if route != nil {
 		params := []gin.Param{}
 		for i, _ := range routePathComponents {
-			if strings.HasPrefix(routePathComponents[i], ":"){
+			if strings.HasPrefix(routePathComponents[i], ":") {
 				params = append(params, gin.Param{
 					Key: routePathComponents[i][1:],
 					Value: requestPathComponents[i],

--- a/pkg/chartmuseum/router/match_test.go
+++ b/pkg/chartmuseum/router/match_test.go
@@ -20,6 +20,8 @@ import (
 	"net/http/httptest"
 	pathutil "path"
 	"testing"
+	"strings"
+	"sort"
 
 	cm_auth "github.com/chartmuseum/auth"
 	"github.com/gin-gonic/gin"
@@ -28,6 +30,28 @@ import (
 
 type MatchTestSuite struct {
 	suite.Suite
+}
+
+type GinParamList struct {
+	params []gin.Param
+}
+
+func (l GinParamList) Len() int {
+	return len(l.params)
+}
+
+func (l GinParamList) Less(a int, b int) bool {
+	return strings.Compare(l.params[a].Key, l.params[b].Key) < 0
+}
+
+func (l GinParamList) Swap(a int, b int) {
+	l.params[a], l.params[b] = l.params[b], l.params[a]
+}
+
+func sortParams(params []gin.Param) []gin.Param {
+	l := GinParamList{params: params}
+	sort.Sort(l)
+	return l.params
 }
 
 func (suite *MatchTestSuite) TestMatch() {
@@ -117,7 +141,7 @@ func (suite *MatchTestSuite) TestMatch() {
 			val, exists = c.Get("index")
 			suite.True(exists)
 			suite.Equal(2, val)
-			suite.Equal([]gin.Param{{"repo", repo}}, params)
+			suite.Equal(sortParams([]gin.Param{{"repo", repo}}), sortParams(params))
 
 			// GET /charts/mychart-0.1.0.tgz
 			r = pathutil.Join("/", contextPath, repo, "charts/mychart-0.1.0.tgz")
@@ -133,7 +157,7 @@ func (suite *MatchTestSuite) TestMatch() {
 			val, exists = c.Get("index")
 			suite.True(exists)
 			suite.Equal(3, val)
-			suite.Equal([]gin.Param{{"filename", "mychart-0.1.0.tgz"}, {"repo", repo}}, params)
+			suite.Equal(sortParams([]gin.Param{{"filename", "mychart-0.1.0.tgz"}, {"repo", repo}}), sortParams(params))
 
 			// GET /api/charts
 			r = pathutil.Join("/", contextPath, "api", repo, "charts")
@@ -149,7 +173,7 @@ func (suite *MatchTestSuite) TestMatch() {
 			val, exists = c.Get("index")
 			suite.True(exists)
 			suite.Equal(4, val)
-			suite.Equal([]gin.Param{{"repo", repo}}, params)
+			suite.Equal(sortParams([]gin.Param{{"repo", repo}}), sortParams(params))
 
 			// GET /api/charts/mychart
 			r = pathutil.Join("/", contextPath, "api", repo, "charts/mychart")
@@ -165,7 +189,7 @@ func (suite *MatchTestSuite) TestMatch() {
 			val, exists = c.Get("index")
 			suite.True(exists)
 			suite.Equal(5, val)
-			suite.Equal([]gin.Param{{"name", "mychart"}, {"repo", repo}}, params)
+			suite.Equal(sortParams([]gin.Param{{"name", "mychart"}, {"repo", repo}}), sortParams(params))
 
 			// GET /api/charts/mychart/0.1.0
 			r = pathutil.Join("/", contextPath, "api", repo, "charts/mychart/0.1.0")
@@ -181,7 +205,7 @@ func (suite *MatchTestSuite) TestMatch() {
 			val, exists = c.Get("index")
 			suite.True(exists)
 			suite.Equal(6, val)
-			suite.Equal([]gin.Param{{"name", "mychart"}, {"version", "0.1.0"}, {"repo", repo}}, params)
+			suite.Equal(sortParams([]gin.Param{{"name", "mychart"}, {"version", "0.1.0"}, {"repo", repo}}), sortParams(params))
 
 			// POST /api/charts
 			r = pathutil.Join("/", contextPath, "api", repo, "charts")
@@ -197,7 +221,7 @@ func (suite *MatchTestSuite) TestMatch() {
 			val, exists = c.Get("index")
 			suite.True(exists)
 			suite.Equal(7, val)
-			suite.Equal([]gin.Param{{"repo", repo}}, params)
+			suite.Equal(sortParams([]gin.Param{{"repo", repo}}), sortParams(params))
 
 			// POST /api/prov
 			r = pathutil.Join("/", contextPath, "api", repo, "prov")
@@ -213,7 +237,7 @@ func (suite *MatchTestSuite) TestMatch() {
 			val, exists = c.Get("index")
 			suite.True(exists)
 			suite.Equal(8, val)
-			suite.Equal([]gin.Param{{"repo", repo}}, params)
+			suite.Equal(sortParams([]gin.Param{{"repo", repo}}), sortParams(params))
 
 			// DELETE /api/charts/mychart/0.1.0
 			r = pathutil.Join("/", contextPath, "api", repo, "charts/mychart/0.1.0")
@@ -229,7 +253,7 @@ func (suite *MatchTestSuite) TestMatch() {
 			val, exists = c.Get("index")
 			suite.True(exists)
 			suite.Equal(9, val)
-			suite.Equal([]gin.Param{{"name", "mychart"}, {"version", "0.1.0"}, {"repo", repo}}, params)
+			suite.Equal(sortParams([]gin.Param{{"name", "mychart"}, {"version", "0.1.0"}, {"repo", repo}}), sortParams(params))
 		}
 	}
 
@@ -247,7 +271,7 @@ func (suite *MatchTestSuite) TestMatch() {
 	val, exists := c.Get("index")
 	suite.True(exists)
 	suite.Equal(2, val)
-	suite.Equal([]gin.Param{{"repo", "apix"}}, params)
+	suite.Equal(sortParams([]gin.Param{{"repo", "apix"}}), sortParams(params))
 
 	r = "/apix/charts/mychart-0.1.0.tgz"
 	route, params = match(routes, "GET", r, "", 1, false)
@@ -262,7 +286,7 @@ func (suite *MatchTestSuite) TestMatch() {
 	val, exists = c.Get("index")
 	suite.True(exists)
 	suite.Equal(3, val)
-	suite.Equal([]gin.Param{{"filename", "mychart-0.1.0.tgz"}, {"repo", "apix"}}, params)
+	suite.Equal(sortParams([]gin.Param{{"filename", "mychart-0.1.0.tgz"}, {"repo", "apix"}}), sortParams(params))
 
 	// Test route repos named just "api"
 	r = "/api/index.yaml"
@@ -278,7 +302,7 @@ func (suite *MatchTestSuite) TestMatch() {
 	val, exists = c.Get("index")
 	suite.True(exists)
 	suite.Equal(2, val)
-	suite.Equal([]gin.Param{{"repo", "api"}}, params)
+	suite.Equal(sortParams([]gin.Param{{"repo", "api"}}), sortParams(params))
 
 	r = "/api/charts/mychart-0.1.0.tgz"
 	route, params = match(routes, "GET", r, "", 1, false)
@@ -293,7 +317,7 @@ func (suite *MatchTestSuite) TestMatch() {
 	val, exists = c.Get("index")
 	suite.True(exists)
 	suite.Equal(3, val)
-	suite.Equal([]gin.Param{{"filename", "mychart-0.1.0.tgz"}, {"repo", "api"}}, params)
+	suite.Equal(sortParams([]gin.Param{{"filename", "mychart-0.1.0.tgz"}, {"repo", "api"}}), sortParams(params))
 
 	// just "api" as repo name, depth=2
 	r = "/api/xyz/index.yaml"
@@ -309,7 +333,7 @@ func (suite *MatchTestSuite) TestMatch() {
 	val, exists = c.Get("index")
 	suite.True(exists)
 	suite.Equal(2, val)
-	suite.Equal([]gin.Param{{"repo", "api/xyz"}}, params)
+	suite.Equal(sortParams([]gin.Param{{"repo", "api/xyz"}}), sortParams(params))
 
 	r = "/api/xyz/charts/mychart-0.1.0.tgz"
 	route, params = match(routes, "GET", r, "", 2, false)
@@ -324,7 +348,7 @@ func (suite *MatchTestSuite) TestMatch() {
 	val, exists = c.Get("index")
 	suite.True(exists)
 	suite.Equal(3, val)
-	suite.Equal([]gin.Param{{"filename", "mychart-0.1.0.tgz"}, {"repo", "api/xyz"}}, params)
+	suite.Equal(sortParams([]gin.Param{{"filename", "mychart-0.1.0.tgz"}, {"repo", "api/xyz"}}), sortParams(params))
 
 	// Test route repos named "health"
 	r = "/health/index.yaml"
@@ -340,7 +364,7 @@ func (suite *MatchTestSuite) TestMatch() {
 	val, exists = c.Get("index")
 	suite.True(exists)
 	suite.Equal(2, val)
-	suite.Equal([]gin.Param{{"repo", "health"}}, params)
+	suite.Equal(sortParams([]gin.Param{{"repo", "health"}}), sortParams(params))
 
 	r = "/health/charts/mychart-0.1.0.tgz"
 	route, params = match(routes, "GET", r, "", 1, false)
@@ -355,7 +379,7 @@ func (suite *MatchTestSuite) TestMatch() {
 	val, exists = c.Get("index")
 	suite.True(exists)
 	suite.Equal(3, val)
-	suite.Equal([]gin.Param{{"filename", "mychart-0.1.0.tgz"}, {"repo", "health"}}, params)
+	suite.Equal(sortParams([]gin.Param{{"filename", "mychart-0.1.0.tgz"}, {"repo", "health"}}), sortParams(params))
 }
 
 func TestMatchTestSuite(t *testing.T) {

--- a/pkg/chartmuseum/server/multitenant/api.go
+++ b/pkg/chartmuseum/server/multitenant/api.go
@@ -30,6 +30,18 @@ import (
 	helm_repo "helm.sh/helm/v3/pkg/repo"
 )
 
+func (server *MultiTenantServer) getAllRepos(log cm_logger.LoggingFn, prefix string) ([]string, *HTTPError) {
+	folders, err := server.StorageBackend.ListFolders(prefix)
+	if err != nil {
+		return nil, &HTTPError{http.StatusInternalServerError, err.Error()}
+	}
+	repos := []string{}
+	for _, folder := range folders {
+			repos = append(repos, folder.Path)
+	}
+	return repos, nil
+}
+
 func (server *MultiTenantServer) getAllCharts(log cm_logger.LoggingFn, repo string, offset int, limit int) (map[string]helm_repo.ChartVersions, *HTTPError) {
 	indexFile, err := server.getIndexFile(log, repo)
 	if err != nil {

--- a/pkg/chartmuseum/server/multitenant/handlers.go
+++ b/pkg/chartmuseum/server/multitenant/handlers.go
@@ -106,6 +106,16 @@ func (server *MultiTenantServer) getStorageObjectRequestHandler(c *gin.Context) 
 	c.Data(200, storageObject.ContentType, storageObject.Content)
 }
 
+func (server *MultiTenantServer) getAllReposRequestHandler(c *gin.Context) {
+	log := server.Logger.ContextLoggingFn(c)
+	repos, err := server.getAllRepos(log, c.Param("repofragment"))
+	if err != nil {
+		c.JSON(err.Status, gin.H{"error": err.Message})
+		return
+	}
+	c.JSON(200, repos)
+}
+
 func (server *MultiTenantServer) getAllChartsRequestHandler(c *gin.Context) {
 	repo := c.Param("repo")
 	offset := 0

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -43,6 +43,7 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 		{"GET", "/api/:repo/charts/:name/:version", s.getChartVersionRequestHandler, cm_auth.PullAction},
 		{"POST", "/api/:repo/charts", s.postRequestHandler, cm_auth.PushAction},
 		{"POST", "/api/:repo/prov", s.postProvenanceFileRequestHandler, cm_auth.PushAction},
+		{"GET", "/api/:repofragment/repos", s.getAllReposRequestHandler, cm_auth.PullAction},
 	}
 
 	routes = append(routes, serverInfoRoutes...)


### PR DESCRIPTION
add an endpoint at `/api/repos` to list repos

- [x] figure out routing??
- [x] add handler
- [x] add tests
- [x] document endpoint

Relies on https://github.com/chartmuseum/storage/pull/48, so once that merges we should revert https://github.com/helm/chartmuseum/pull/364/commits/5ca02f608563175cc4e9dbbf624f8f28c0aa1b34