### PR TITLE
Update readme steps, missing params in the helm cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ helm repo add chartmuseum http://localhost:8080
 
 Search for charts:
 ```bash
-helm search chartmuseum/
+helm search repo chartmuseum/
 ```
 
 Install chart:
 ```bash
-helm install chartmuseum/mychart
+helm install chartmuseum/mychart --generate-name
 ```
 
 ## How to Run


### PR DESCRIPTION
Following the steps with helm `3.4.0` was not possible. I have updated the commands in the readme