### PR TITLE
Add scbizu to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,4 @@
 maintainers:
-  - jdolitsky
   - davidovich
+  - jdolitsky
+  - scbizu


### PR DESCRIPTION
Add @scbizu as ChartMuseum project maintainer. They have helped with new feature development and answered user questions in the general issue queue, and also expressed interest in this role via private message.

@davidovich please review - this requires super-majority vote of project maintainers according to Helm's governance docs: https://github.com/helm/community/blob/master/governance/governance.md#project-maintainers