### PR TITLE
proposal: work on increasing the server throughout.

### DIFF
--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -18,13 +18,14 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"strings"
+
 	"github.com/chartmuseum/storage"
 	"helm.sh/chartmuseum/pkg/cache"
 	"helm.sh/chartmuseum/pkg/chartmuseum"
 	"helm.sh/chartmuseum/pkg/config"
-	"log"
-	"os"
-	"strings"
 
 	"github.com/urfave/cli"
 )
@@ -62,46 +63,47 @@ func cliHandler(c *cli.Context) {
 	store := storeFromConfig(conf)
 
 	options := chartmuseum.ServerOptions{
-		Version:                Version,
-		StorageBackend:         backend,
-		ExternalCacheStore:     store,
-		TimestampTolerance:     conf.GetDuration("storage.timestamptolerance"),
-		ChartURL:               conf.GetString("charturl"),
-		TlsCert:                conf.GetString("tls.cert"),
-		TlsKey:                 conf.GetString("tls.key"),
-		TlsCACert:              conf.GetString("tls.cacert"),
-		Username:               conf.GetString("basicauth.user"),
-		Password:               conf.GetString("basicauth.pass"),
-		ChartPostFormFieldName: conf.GetString("chartpostformfieldname"),
-		ProvPostFormFieldName:  conf.GetString("provpostformfieldname"),
-		ContextPath:            conf.GetString("contextpath"),
-		LogJSON:                conf.GetBool("logjson"),
-		LogHealth:              conf.GetBool("loghealth"),
-		LogLatencyInteger:      conf.GetBool("loglatencyinteger"),
-		Debug:                  conf.GetBool("debug"),
-		EnableAPI:              !conf.GetBool("disableapi"),
-		DisableDelete:          conf.GetBool("disabledelete"),
-		UseStatefiles:          !conf.GetBool("disablestatefiles"),
-		AllowOverwrite:         conf.GetBool("allowoverwrite"),
-		AllowForceOverwrite:    !conf.GetBool("disableforceoverwrite"),
-		EnableMetrics:          !conf.GetBool("disablemetrics"),
-		AnonymousGet:           conf.GetBool("authanonymousget"),
-		GenIndex:               conf.GetBool("genindex"),
-		MaxStorageObjects:      conf.GetInt("maxstorageobjects"),
-		IndexLimit:             conf.GetInt("indexlimit"),
-		Depth:                  conf.GetInt("depth"),
-		MaxUploadSize:          conf.GetInt("maxuploadsize"),
-		BearerAuth:             conf.GetBool("bearerauth"),
-		AuthRealm:              conf.GetString("authrealm"),
-		AuthService:            conf.GetString("authservice"),
-		AuthCertPath:           conf.GetString("authcertpath"),
-		DepthDynamic:           conf.GetBool("depthdynamic"),
-		CORSAllowOrigin:        conf.GetString("cors.alloworigin"),
-		WriteTimeout:           conf.GetInt("writetimeout"),
-		ReadTimeout:            conf.GetInt("readtimeout"),
-		EnforceSemver2:         conf.GetBool("enforce-semver2"),
-		CacheInterval:          conf.GetDuration("cacheinterval"),
-		Host:                   conf.GetString("listen.host"),
+		Version:                 Version,
+		StorageBackend:          backend,
+		ExternalCacheStore:      store,
+		TimestampTolerance:      conf.GetDuration("storage.timestamptolerance"),
+		ChartURL:                conf.GetString("charturl"),
+		TlsCert:                 conf.GetString("tls.cert"),
+		TlsKey:                  conf.GetString("tls.key"),
+		TlsCACert:               conf.GetString("tls.cacert"),
+		Username:                conf.GetString("basicauth.user"),
+		Password:                conf.GetString("basicauth.pass"),
+		ChartPostFormFieldName:  conf.GetString("chartpostformfieldname"),
+		ProvPostFormFieldName:   conf.GetString("provpostformfieldname"),
+		ContextPath:             conf.GetString("contextpath"),
+		LogJSON:                 conf.GetBool("logjson"),
+		LogHealth:               conf.GetBool("loghealth"),
+		LogLatencyInteger:       conf.GetBool("loglatencyinteger"),
+		Debug:                   conf.GetBool("debug"),
+		EnableAPI:               !conf.GetBool("disableapi"),
+		DisableDelete:           conf.GetBool("disabledelete"),
+		UseStatefiles:           !conf.GetBool("disablestatefiles"),
+		AllowOverwrite:          conf.GetBool("allowoverwrite"),
+		AllowForceOverwrite:     !conf.GetBool("disableforceoverwrite"),
+		EnableMetrics:           !conf.GetBool("disablemetrics"),
+		AnonymousGet:            conf.GetBool("authanonymousget"),
+		GenIndex:                conf.GetBool("genindex"),
+		MaxStorageObjects:       conf.GetInt("maxstorageobjects"),
+		IndexLimit:              conf.GetInt("indexlimit"),
+		Depth:                   conf.GetInt("depth"),
+		MaxUploadSize:           conf.GetInt("maxuploadsize"),
+		BearerAuth:              conf.GetBool("bearerauth"),
+		AuthRealm:               conf.GetString("authrealm"),
+		AuthService:             conf.GetString("authservice"),
+		AuthCertPath:            conf.GetString("authcertpath"),
+		DepthDynamic:            conf.GetBool("depthdynamic"),
+		CORSAllowOrigin:         conf.GetString("cors.alloworigin"),
+		WriteTimeout:            conf.GetInt("writetimeout"),
+		ReadTimeout:             conf.GetInt("readtimeout"),
+		EnforceSemver2:          conf.GetBool("enforce-semver2"),
+		CacheInterval:           conf.GetDuration("cacheinterval"),
+		KeepChartAlwaysUpToDate: conf.GetBool("keep-chart-always-up-to-date"),
+		Host:                    conf.GetString("listen.host"),
 	}
 
 	server, err := newServer(options)

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -69,9 +69,12 @@ type (
 		// EnforceSemver2 represents if the museum server always accept the Chart with [valid semantic version 2](https://semver.org/)
 		// More refers to : https://github.com/helm/chartmuseum/issues/320
 		EnforceSemver2 bool
-		CacheInterval  time.Duration
-		Host           string
-		Version        string
+		// KeepChartAlwaysUpToDate represents if the museum always return the up-to-date chart
+		// which means that the GetChart will increase its latency , be careful to enable this .
+		KeepChartAlwaysUpToDate bool
+		CacheInterval           time.Duration
+		Host                    string
+		Version                 string
 	}
 
 	// Server is a generic interface for web servers
@@ -121,25 +124,26 @@ func NewServer(options ServerOptions) (Server, error) {
 	})
 
 	server, err := mt.NewMultiTenantServer(mt.MultiTenantServerOptions{
-		Logger:                 logger,
-		Router:                 router,
-		StorageBackend:         options.StorageBackend,
-		ExternalCacheStore:     options.ExternalCacheStore,
-		TimestampTolerance:     options.TimestampTolerance,
-		ChartURL:               strings.TrimSuffix(options.ChartURL, "/"),
-		ChartPostFormFieldName: options.ChartPostFormFieldName,
-		ProvPostFormFieldName:  options.ProvPostFormFieldName,
-		MaxStorageObjects:      options.MaxStorageObjects,
-		IndexLimit:             options.IndexLimit,
-		GenIndex:               options.GenIndex,
-		EnableAPI:              options.EnableAPI,
-		DisableDelete:          options.DisableDelete,
-		UseStatefiles:          options.UseStatefiles,
-		AllowOverwrite:         options.AllowOverwrite,
-		AllowForceOverwrite:    options.AllowForceOverwrite,
-		EnforceSemver2:         options.EnforceSemver2,
-		Version:                options.Version,
-		CacheInterval:          options.CacheInterval,
+		Logger:                  logger,
+		Router:                  router,
+		StorageBackend:          options.StorageBackend,
+		ExternalCacheStore:      options.ExternalCacheStore,
+		TimestampTolerance:      options.TimestampTolerance,
+		ChartURL:                strings.TrimSuffix(options.ChartURL, "/"),
+		ChartPostFormFieldName:  options.ChartPostFormFieldName,
+		ProvPostFormFieldName:   options.ProvPostFormFieldName,
+		MaxStorageObjects:       options.MaxStorageObjects,
+		IndexLimit:              options.IndexLimit,
+		GenIndex:                options.GenIndex,
+		EnableAPI:               options.EnableAPI,
+		DisableDelete:           options.DisableDelete,
+		UseStatefiles:           options.UseStatefiles,
+		AllowOverwrite:          options.AllowOverwrite,
+		AllowForceOverwrite:     options.AllowForceOverwrite,
+		EnforceSemver2:          options.EnforceSemver2,
+		Version:                 options.Version,
+		CacheInterval:           options.CacheInterval,
+		KeepChartAlwaysUpToDate: options.KeepChartAlwaysUpToDate,
 	})
 
 	return server, err

--- a/pkg/chartmuseum/server/multitenant/handlers.go
+++ b/pkg/chartmuseum/server/multitenant/handlers.go
@@ -211,7 +211,7 @@ func (server *MultiTenantServer) deleteChartVersionRequestHandler(c *gin.Context
 		return
 	}
 
-	server.emitEvent(c, repo, deleteChart, &helm_repo.ChartVersion{
+	go server.emitEvent(c, repo, deleteChart, &helm_repo.ChartVersion{
 		Metadata: &chart.Metadata{
 			Name:    name,
 			Version: version,
@@ -267,7 +267,7 @@ func (server *MultiTenantServer) postPackageRequestHandler(c *gin.Context) {
 	if chartErr != nil {
 		log(cm_logger.ErrorLevel, "cannot get chart from content", zap.Error(chartErr), zap.Binary("content", content))
 	}
-	server.emitEvent(c, repo, action, chart)
+	go server.emitEvent(c, repo, action, chart)
 
 	c.JSON(201, objectSavedResponse)
 }
@@ -350,7 +350,7 @@ func (server *MultiTenantServer) postPackageAndProvenanceRequestHandler(c *gin.C
 		log(cm_logger.ErrorLevel, "cannot get chart from content", zap.Error(err), zap.Binary("content", chartContent))
 	}
 
-	server.emitEvent(c, repo, addChart, chart)
+	go server.emitEvent(c, repo, addChart, chart)
 
 	c.JSON(201, objectSavedResponse)
 }

--- a/pkg/chartmuseum/server/multitenant/index.go
+++ b/pkg/chartmuseum/server/multitenant/index.go
@@ -39,8 +39,8 @@ func (server *MultiTenantServer) getIndexFile(log cm_logger.LoggingFn, repo stri
 		return nil, &HTTPError{http.StatusInternalServerError, errStr}
 	}
 
-	// if cache is nil, and not on a timer, regenerate it
-	if len(entry.RepoIndex.Entries) == 0 && server.CacheInterval == 0 {
+	// if cache interval not set, regenerate it
+	if server.CacheInterval == 0 {
 
 		fo := <-server.getChartList(log, repo)
 

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -45,52 +45,54 @@ const (
 type (
 	// MultiTenantServer contains a Logger, Router, storage backend and object cache
 	MultiTenantServer struct {
-		Logger                 *cm_logger.Logger
-		Router                 *cm_router.Router
-		StorageBackend         storage.Backend
-		TimestampTolerance     time.Duration
-		ExternalCacheStore     cache.Store
-		InternalCacheStore     map[string]*cacheEntry
-		MaxStorageObjects      int
-		IndexLimit             int
-		AllowOverwrite         bool
-		AllowForceOverwrite    bool
-		APIEnabled             bool
-		DisableDelete          bool
-		UseStatefiles          bool
-		EnforceSemver2         bool
-		ChartURL               string
-		ChartPostFormFieldName string
-		ProvPostFormFieldName  string
-		Version                string
-		Limiter                chan struct{}
-		Tenants                map[string]*tenantInternals
-		TenantCacheKeyLock     *sync.Mutex
-		CacheInterval          time.Duration
-		EventChan              chan event
+		Logger                  *cm_logger.Logger
+		Router                  *cm_router.Router
+		StorageBackend          storage.Backend
+		TimestampTolerance      time.Duration
+		ExternalCacheStore      cache.Store
+		InternalCacheStore      map[string]*cacheEntry
+		MaxStorageObjects       int
+		IndexLimit              int
+		AllowOverwrite          bool
+		AllowForceOverwrite     bool
+		APIEnabled              bool
+		DisableDelete           bool
+		UseStatefiles           bool
+		EnforceSemver2          bool
+		KeepChartAlwaysUpToDate bool
+		ChartURL                string
+		ChartPostFormFieldName  string
+		ProvPostFormFieldName   string
+		Version                 string
+		Limiter                 chan struct{}
+		Tenants                 map[string]*tenantInternals
+		TenantCacheKeyLock      *sync.Mutex
+		CacheInterval           time.Duration
+		EventChan               chan event
 	}
 
 	// MultiTenantServerOptions are options for constructing a MultiTenantServer
 	MultiTenantServerOptions struct {
-		Logger                 *cm_logger.Logger
-		Router                 *cm_router.Router
-		StorageBackend         storage.Backend
-		ExternalCacheStore     cache.Store
-		TimestampTolerance     time.Duration
-		ChartURL               string
-		ChartPostFormFieldName string
-		ProvPostFormFieldName  string
-		Version                string
-		MaxStorageObjects      int
-		IndexLimit             int
-		GenIndex               bool
-		AllowOverwrite         bool
-		AllowForceOverwrite    bool
-		EnableAPI              bool
-		DisableDelete          bool
-		UseStatefiles          bool
-		EnforceSemver2         bool
-		CacheInterval          time.Duration
+		Logger                  *cm_logger.Logger
+		Router                  *cm_router.Router
+		StorageBackend          storage.Backend
+		ExternalCacheStore      cache.Store
+		TimestampTolerance      time.Duration
+		ChartURL                string
+		ChartPostFormFieldName  string
+		ProvPostFormFieldName   string
+		Version                 string
+		MaxStorageObjects       int
+		IndexLimit              int
+		GenIndex                bool
+		AllowOverwrite          bool
+		AllowForceOverwrite     bool
+		EnableAPI               bool
+		DisableDelete           bool
+		UseStatefiles           bool
+		EnforceSemver2          bool
+		CacheInterval           time.Duration
+		KeepChartAlwaysUpToDate bool
 	}
 
 	tenantInternals struct {
@@ -119,28 +121,29 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 	}
 
 	server := &MultiTenantServer{
-		Logger:                 options.Logger,
-		Router:                 options.Router,
-		StorageBackend:         options.StorageBackend,
-		TimestampTolerance:     options.TimestampTolerance,
-		ExternalCacheStore:     options.ExternalCacheStore,
-		InternalCacheStore:     map[string]*cacheEntry{},
-		MaxStorageObjects:      options.MaxStorageObjects,
-		IndexLimit:             options.IndexLimit,
-		ChartURL:               chartURL,
-		ChartPostFormFieldName: options.ChartPostFormFieldName,
-		ProvPostFormFieldName:  options.ProvPostFormFieldName,
-		AllowOverwrite:         options.AllowOverwrite,
-		AllowForceOverwrite:    options.AllowForceOverwrite,
-		APIEnabled:             options.EnableAPI,
-		DisableDelete:          options.DisableDelete,
-		UseStatefiles:          options.UseStatefiles,
-		EnforceSemver2:         options.EnforceSemver2,
-		Version:                options.Version,
-		Limiter:                make(chan struct{}, options.IndexLimit),
-		Tenants:                map[string]*tenantInternals{},
-		TenantCacheKeyLock:     &sync.Mutex{},
-		CacheInterval:          options.CacheInterval,
+		Logger:                  options.Logger,
+		Router:                  options.Router,
+		StorageBackend:          options.StorageBackend,
+		TimestampTolerance:      options.TimestampTolerance,
+		ExternalCacheStore:      options.ExternalCacheStore,
+		InternalCacheStore:      map[string]*cacheEntry{},
+		MaxStorageObjects:       options.MaxStorageObjects,
+		IndexLimit:              options.IndexLimit,
+		ChartURL:                chartURL,
+		ChartPostFormFieldName:  options.ChartPostFormFieldName,
+		ProvPostFormFieldName:   options.ProvPostFormFieldName,
+		AllowOverwrite:          options.AllowOverwrite,
+		AllowForceOverwrite:     options.AllowForceOverwrite,
+		APIEnabled:              options.EnableAPI,
+		DisableDelete:           options.DisableDelete,
+		UseStatefiles:           options.UseStatefiles,
+		EnforceSemver2:          options.EnforceSemver2,
+		Version:                 options.Version,
+		Limiter:                 make(chan struct{}, options.IndexLimit),
+		Tenants:                 map[string]*tenantInternals{},
+		TenantCacheKeyLock:      &sync.Mutex{},
+		CacheInterval:           options.CacheInterval,
+		KeepChartAlwaysUpToDate: options.KeepChartAlwaysUpToDate,
 	}
 
 	server.Router.SetRoutes(server.Routes())


### PR DESCRIPTION
The patch includes:

* increases most of the museum api throughout by wrapping the event
  emitter into goroutine since the event listener already holds on the
  concurrent lock(#396).

* adds the new server option `keep-chart-always-up-to-date` to force use
  the latest version. (maybe not always work in high concurrent environment)

* `getIndexFile` rollbacks to fully reload index only if cacheinterval
  not set for better backward compatibility before v0.13.0(#444).


But still need some more load-testing ...