### PR TITLE
[WIP] Add support for Metadata

### DIFF
--- a/pkg/chartmuseum/server/multitenant/handlers.go
+++ b/pkg/chartmuseum/server/multitenant/handlers.go
@@ -293,6 +293,26 @@ func (server *MultiTenantServer) postProvenanceFileRequestHandler(c *gin.Context
 	c.JSON(201, objectSavedResponse)
 }
 
+func (server *MultiTenantServer) postMetaFileRequestHandler(c *gin.Context) {
+	repo := c.Param("repo")
+	content, getContentErr := c.GetRawData()
+	if getContentErr != nil {
+		if len(c.Errors) > 0 {
+			return // this is a "request too large"
+		}
+		c.JSON(500, gin.H{"error": fmt.Sprintf("%s", getContentErr)})
+		return
+	}
+	log := server.Logger.ContextLoggingFn(c)
+	_, force := c.GetQuery("force")
+	err := server.uploadMetaFile(log, repo, content, force)
+	if err != nil {
+		c.JSON(err.Status, gin.H{"error": err.Message})
+		return
+	}
+	c.JSON(201, objectSavedResponse)
+}
+
 func (server *MultiTenantServer) postPackageAndProvenanceRequestHandler(c *gin.Context) {
 	log := server.Logger.ContextLoggingFn(&gin.Context{})
 	repo := c.Param("repo")

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -43,7 +43,9 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 		{"HEAD", "/api/:repo/charts/:name/:version", s.headChartVersionRequestHandler, cm_auth.PullAction},
 		{"GET", "/api/:repo/charts/:name/:version", s.getChartVersionRequestHandler, cm_auth.PullAction},
 		{"POST", "/api/:repo/charts", s.postRequestHandler, cm_auth.PushAction},
-		{"POST", "/api/:repo/prov", s.postProvenanceFileRequestHandler, cm_auth.PushAction},
+			{"POST", "/api/:repo/prov", s.postProvenanceFileRequestHandler, cm_auth.PushAction},
+
+		{"POST", "/api/:repo/meta", s.postMetaFileRequestHandler, cm_auth.PushAction},
 	}
 
 	routes = append(routes, serverInfoRoutes...)

--- a/pkg/chartmuseum/server/multitenant/storage.go
+++ b/pkg/chartmuseum/server/multitenant/storage.go
@@ -30,6 +30,7 @@ import (
 var (
 	chartPackageContentType   = "application/x-tar"
 	provenanceFileContentType = "application/pgp-signature"
+	MetaFileContentType = "application/json"
 )
 
 type (
@@ -42,7 +43,8 @@ type (
 func (server *MultiTenantServer) getStorageObject(log cm_logger.LoggingFn, repo string, filename string) (*StorageObject, *HTTPError) {
 	isChartPackage := strings.HasSuffix(filename, cm_repo.ChartPackageFileExtension)
 	isProvenanceFile := strings.HasSuffix(filename, cm_repo.ProvenanceFileExtension)
-	if !isChartPackage && !isProvenanceFile {
+	isMetaFile := strings.HasSuffix(filename, cm_repo.MetaFileExtension)
+	if !isChartPackage && !isProvenanceFile && !isMetaFile {
 		log(cm_logger.WarnLevel, "unsupported file extension",
 			"repo", repo,
 			"filename", filename,
@@ -66,6 +68,8 @@ func (server *MultiTenantServer) getStorageObject(log cm_logger.LoggingFn, repo 
 	var contentType string
 	if isProvenanceFile {
 		contentType = provenanceFileContentType
+	} else if isMetaFile {
+		contentType = MetaFileContentType
 	} else {
 		contentType = chartPackageContentType
 	}

--- a/pkg/repo/meta.go
+++ b/pkg/repo/meta.go
@@ -1,0 +1,36 @@
+package repo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+var (
+	// MetaFileExtension is the file extension used for meta files
+	MetaFileExtension = "tgz.meta"
+
+	// MetaFileContentType is the http content-type header for meta files
+	MetaFileContentType = "application/json"
+
+	// ErrorInvalidMetaFile is raised when a meta file is invalid
+	ErrorInvalidMetaFile = errors.New("invalid meta file")
+)
+
+// MetaFilenameFromNameVersion returns a meta filename from a name and version
+func MetaFilenameFromNameVersion(name string, version string) string {
+	filename := fmt.Sprintf("%s-%s.%s", name, version, MetaFileExtension)
+	return filename
+}
+
+// MetaFilenameFromContent returns a meta filename from binary content
+func MetaFilenameFromContent(content []byte) (string, error) {
+	var contentJSON map[string]interface{}
+	json.Unmarshal(content[:], &contentJSON)
+
+	if contentJSON["version"] == nil || contentJSON["name"] == nil {
+		return "", ErrorInvalidMetaFile
+	}
+	filename := MetaFilenameFromNameVersion(fmt.Sprintf("%v", contentJSON["name"]), fmt.Sprintf("%v", contentJSON["version"]))
+	return filename, nil
+}

--- a/pkg/repo/meta_test.go
+++ b/pkg/repo/meta_test.go
@@ -1,0 +1,53 @@
+package repo
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type MetaTestSuite struct {
+	suite.Suite
+}
+
+func (suite *MetaTestSuite) TestMetaFileFilenameFromContent() {
+	goodContent := []byte(`{
+"name": "mychart",
+"version": "0.1.0",
+"tests_passed": true
+}`)
+
+	badContentMalformedJSON := []byte(`{
+"name": "mychart"
+"version": "0.1.0",
+"tests_passed": true
+}`)
+
+	badContentNoChartName := []byte(`{
+"version": "0.1.0",
+"tests_passed": true
+}`)
+
+	badContentNoChartVersion := []byte(`{
+"name": "mychart"",
+"tests_passed": true
+}`)
+
+
+
+	filename, err := MetaFilenameFromContent(goodContent)
+	suite.Nil(err, "no error getting filename from good content")
+	suite.Equal("mychart-0.1.0.tgz.meta", filename, "filename generated from good content")
+
+	_, err = MetaFilenameFromContent(badContentMalformedJSON)
+	suite.Equal(ErrorInvalidMetaFile, err, "ErrorInvalidMetaFile from bad content, Malformed json")
+
+	_, err = MetaFilenameFromContent(badContentNoChartName)
+	suite.Equal(ErrorInvalidMetaFile, err, "ErrorInvalidMetaFile from bad content, no name")
+
+	_, err = MetaFilenameFromContent(badContentNoChartVersion)
+	suite.Equal(ErrorInvalidMetaFile, err, "ErrorInvalidMetaFile from bad content, no version")
+}
+
+func TestMetaTestSuite(t *testing.T) {
+	suite.Run(t, new(MetaTestSuite))
+}


### PR DESCRIPTION
## Background
It's useful as part of a build/release process to be able to store metadata about a particular chart. For example you might have a chart that builds successfully but fails integration tests, this is still a valid build / chart but is unlikely to be releasable. 

Currently there is no way to tell the state of a chart in CM, this adds a simple file in the spirit of `.prov` called `.meta`. 
With the format:
```
{
  "name": "mychart",
  "version": "0.1.0",
  "somekey": "someval",
  "tests_passed": true,
  "override_deploy": true,
}
```

`curl --data-binary "@mychart-0.1.0.tgz.meta" http://localhost:8080/api/meta`

The only two reserved K/V pairs being `name` and `version` which must match the chart that the meta data is associated with. (Maybe `creation_ts` and `last_update_ts` needs to be reserved too???)



Opening this WIP now as others may have ideas for better implementation or comments on current process. 


Dummy Usecase 1:
1 . Build docker containers
2. Generate Helm Chart and upload to CM
3. deploy helm chart to some env
4. run acceptance / integration tests
5. update mychart-0.1.0.tgz.meta with `"tests_passed": true`
6. Some deployment process pulls chart.meta and checks K/V pairs for matches
7. Deployment process takes action depending on K/V pair E.g. Deploy or Not

## Limitations of this implementation
* Customers must write there own search / parser CM just hosts the metadata it's up to the customer to process it. Perhaps a later addition will be to let this be searched 
* Not easily searchable - I had thought sticking this in redis etc would be a better way and maybe long term  or for more advanced setup a build meta data server could be useful but this is a easy start that lets less advanced setups not worry about that complexity. 
