### PR TITLE
Add per chart limit option

### DIFF
--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -104,6 +104,7 @@ func cliHandler(c *cli.Context) {
 		EnforceSemver2:         conf.GetBool("enforce-semver2"),
 		CacheInterval:          conf.GetDuration("cacheinterval"),
 		Host:                   conf.GetString("listen.host"),
+		PerChartLimit:          conf.GetInt("per-chart-limit"),
 	}
 
 	server, err := newServer(options)

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -72,6 +72,9 @@ type (
 		CacheInterval  time.Duration
 		Host           string
 		Version        string
+		// PerChartLimit allow museum server to keep max N version Charts
+		// And avoid swelling too large(if so , the index genertion will become slow)
+		PerChartLimit int
 	}
 
 	// Server is a generic interface for web servers
@@ -140,6 +143,7 @@ func NewServer(options ServerOptions) (Server, error) {
 		AllowForceOverwrite:    options.AllowForceOverwrite,
 		Version:                options.Version,
 		CacheInterval:          options.CacheInterval,
+		PerChartLimit:          options.PerChartLimit,
 		// Deprecated options
 		// EnforceSemver2 - see https://github.com/helm/chartmuseum/issues/485 for more info
 		EnforceSemver2: options.EnforceSemver2,

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -775,6 +775,15 @@ var configVars = map[string]configVar{
 			EnvVar: "LISTEN_HOST",
 		},
 	},
+	"per-chart-limit": {
+		Type:    intType,
+		Default: 0,
+		CLIFlag: cli.IntFlag{
+			Name:   "per-chart-limit",
+			Usage:  "limits the museum server stores the max N versions per chart",
+			EnvVar: "PER_CHART_LIMIT",
+		},
+	},
 }
 
 func populateCLIFlags() {

--- a/scripts/setup-test-environment.sh
+++ b/scripts/setup-test-environment.sh
@@ -49,6 +49,8 @@ package_test_charts() {
     done
     # add another version to repo for metric tests
     helm package --sign --key helm-test --keyring ../pgp/helm-test-key.secret --version 0.2.0 -d mychart/ mychart/.
+    # add another version for per chart limit test
+    helm package --sign --key helm-test --keyring ../pgp/helm-test-key.secret --version 0.0.1 -d mychart/ mychart/.
     popd
 
     pushd testdata/badcharts/
@@ -57,6 +59,7 @@ package_test_charts() {
         helm package .
         popd
     done
+    popd
 }
 
 main


### PR DESCRIPTION
impls #316 

Also , closes #376 

- [x] backend storage and index cache supports per chart limit

Maybe in next release:

-  lock chart to be unremovable
-  provide a dry run command to clean museum(per chart) , also works with chart lock mechanism
