### PR TITLE
Support Builds for ARM M1 Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ BINNAME     ?= chartmuseum
 # Required for globs to work correctly
 SHELL      = /usr/bin/env bash
 
-TARGETS     := darwin/amd64 linux/amd64 linux/386 linux/arm linux/arm64 linux/mips64le linux/ppc64le linux/s390x windows/amd64
-TARGET_OBJS ?= darwin-amd64.tar.gz darwin-amd64.tar.gz.sha256sum linux-amd64.tar.gz linux-amd64.tar.gz.sha256sum linux-386.tar.gz linux-386.tar.gz.sha256sum linux-arm.tar.gz linux-arm.tar.gz.sha256sum linux-arm64.tar.gz linux-arm64.tar.gz.sha256sum linux-mips64le.tar.gz linux-mips64le.tar.gz.sha256sum linux-ppc64le.tar.gz linux-ppc64le.tar.gz.sha256sum linux-s390x.tar.gz linux-s390x.tar.gz.sha256sum windows-amd64.zip windows-amd64.zip.sha256sum
+TARGETS     := darwin/amd64 darwin/arm64 linux/amd64 linux/386 linux/arm linux/arm64 linux/mips64le linux/ppc64le linux/s390x windows/amd64
+TARGET_OBJS ?= darwin-amd64.tar.gz darwin-amd64.tar.gz.sha256sum darwin-arm64.tar.gz darwin-arm64.tar.gz.sha256sum linux-amd64.tar.gz linux-amd64.tar.gz.sha256sum linux-386.tar.gz linux-386.tar.gz.sha256sum linux-arm.tar.gz linux-arm.tar.gz.sha256sum linux-arm64.tar.gz linux-arm64.tar.gz.sha256sum linux-mips64le.tar.gz linux-mips64le.tar.gz.sha256sum linux-ppc64le.tar.gz linux-ppc64le.tar.gz.sha256sum linux-s390x.tar.gz linux-s390x.tar.gz.sha256sum windows-amd64.zip windows-amd64.zip.sha256sum
 
 DIST_DIRS   := find * -type d -exec
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ bootstrap:
 	@go mod download && go mod vendor
 
 .PHONY: build
-build: build-linux build-mac build-windows build-linux-mips
+build: build-linux build-mac build-mac-arm build-windows build-linux-mips
 
 build-windows: export GOOS=windows
 build-windows: export GOARCH=amd64
@@ -81,6 +81,17 @@ build-mac:
 	go build -v --ldflags="-w -X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
 		-o bin/darwin/amd64/chartmuseum cmd/chartmuseum/main.go # mac osx
 	sha256sum bin/darwin/amd64/chartmuseum || shasum -a 256 bin/darwin/amd64/chartmuseum
+
+.PHONY: build-mac-arm
+build-mac-arm: export GOOS=darwin
+build-mac-arm: export GOARCH=arm64
+build-mac-arm: export CGO_ENABLED=0
+build-mac-arm: export GO111MODULE=on
+build-mac-arm: export GOPROXY=$(MOD_PROXY_URL)
+build-mac-arm:
+	go build -v --ldflags="-w -X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
+		-o bin/darwin/arm64/chartmuseum cmd/chartmuseum/main.go # mac osx
+	sha256sum bin/darwin/arm64/chartmuseum || shasum -a 256 bin/darwin/arm64/chartmuseum
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ bootstrap:
 .PHONY: build
 build: build-linux build-mac build-mac-arm build-windows build-linux-mips
 
+.PHONY: build-windows
 build-windows: export GOOS=windows
 build-windows: export GOARCH=amd64
 build-windows: export GO111MODULE=on
@@ -41,6 +42,7 @@ build-windows:
 		-o bin/windows/amd64/chartmuseum cmd/chartmuseum/main.go  # windows
 	sha256sum bin/windows/amd64/chartmuseum || shasum -a 256 bin/windows/amd64/chartmuseum
 
+.PHONY: build-linux
 build-linux: export GOOS=linux
 build-linux: export GOARCH=amd64
 build-linux: export CGO_ENABLED=0
@@ -51,6 +53,7 @@ build-linux:
 		-o bin/linux/amd64/chartmuseum cmd/chartmuseum/main.go  # linux
 	sha256sum bin/linux/amd64/chartmuseum || shasum -a 256 bin/linux/amd64/chartmuseum
 
+.PHONY: build-linux-mips
 build-linux-mips: export GOOS=linux
 build-linux-mips: export GOARCH=mips64le
 build-linux-mips: export CGO_ENABLED=0
@@ -61,7 +64,7 @@ build-linux-mips:
 		-o bin/linux/mips64/chartmuseum cmd/chartmuseum/main.go  # linux
 	sha256sum bin/linux/mips64/chartmuseum || shasum -a 256 bin/linux/mips64/chartmuseum
 
-
+.PHONY: build-armv7
 build-armv7: export GOOS=linux
 build-armv7: export GOARCH=arm
 build-armv7: export GOARM=7
@@ -72,6 +75,7 @@ build-armv7:
 	go build -v --ldflags="-w -X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
 		-o bin/linux/armv7/chartmuseum cmd/chartmuseum/main.go  # linux
 
+.PHONY: build-mac
 build-mac: export GOOS=darwin
 build-mac: export GOARCH=amd64
 build-mac: export CGO_ENABLED=0

--- a/scripts/get-chartmuseum
+++ b/scripts/get-chartmuseum
@@ -36,7 +36,7 @@ initArch() {
     armv5*) ARCH="armv5";;
     armv6*) ARCH="armv6";;
     armv7*) ARCH="arm";;
-    aarch64) ARCH="arm64";;
+    aarch64|arm64) ARCH="arm64";;
     x86) ARCH="386";;
     x86_64) ARCH="amd64";;
     i686) ARCH="386";;
@@ -68,7 +68,7 @@ runAsRoot() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds, as well whether or not necessary tools are present.
 verifySupported() {
-  local supported="darwin-amd64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nlinux-ppc64le\nlinux-s390x\nwindows-amd64"
+  local supported="darwin-amd64\ndarwin-arm64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nlinux-ppc64le\nlinux-s390x\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuilt binary for ${OS}-${ARCH}."
     echo "To build from source, go to https://github.com/helm/chartmuseum"


### PR DESCRIPTION
## Summary
This PR adds build targets to the makefile to support building for darwin/arm64, which is the architecture for Apples processors going forward from the M1.

It also adds support for the arch in the get-chartmuseum script, which will then attempt to download the version. As soon as the first version with this build is released, everybody can enjoy it :)

Also added `.PHONY` labels to the other build-* targets, to prevent make confusion when files called build-* exist.

## Testing

Successfully tested on an M1 MBP, macOS 11.5.2.

## Caveat

Unfortunately, there is a cosmetic error message at the start coming from containerd, because it tries to call `getCPUInfo()` on every ARM arch:
```
ERRO[0000] failure getting variant                       error="getCPUInfo for OS darwin: not implemented"
```
See https://github.com/containerd/containerd/blob/v1.3.4/platforms/cpuinfo.go#L77-L93.

The bug is already fixed since 1.4.0 of containerd/containerd: https://github.com/containerd/containerd/commit/7119a2a152edcf517a6cbc3271794c720bff2bd8, but indirect dependencies still pull in old versions.
