### PR TITLE
feat: Add configuration deprecation warning logs

### DIFF
--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chartmuseum/storage"
 	"helm.sh/chartmuseum/pkg/cache"
 	"helm.sh/chartmuseum/pkg/chartmuseum"
+	cm_logger "helm.sh/chartmuseum/pkg/chartmuseum/logger"
 	"helm.sh/chartmuseum/pkg/config"
 
 	"github.com/urfave/cli"
@@ -59,6 +60,16 @@ func cliHandler(c *cli.Context) {
 		crash(err)
 	}
 
+	logger, err := cm_logger.NewLogger(cm_logger.LoggerOptions{
+		Debug:   conf.GetBool("debug"),
+		LogJSON: conf.GetBool("logjson"),
+	})
+	if err != nil {
+		crash(err)
+	}
+
+	conf.ShowDeprecationWarnings(c, logger)
+
 	backend := backendFromConfig(conf)
 	store := storeFromConfig(conf)
 
@@ -66,6 +77,7 @@ func cliHandler(c *cli.Context) {
 		Version:                Version,
 		StorageBackend:         backend,
 		ExternalCacheStore:     store,
+		Logger:                 logger,
 		TimestampTolerance:     conf.GetDuration("storage.timestamptolerance"),
 		ChartURL:               conf.GetString("charturl"),
 		TlsCert:                conf.GetString("tls.cert"),
@@ -76,10 +88,8 @@ func cliHandler(c *cli.Context) {
 		ChartPostFormFieldName: conf.GetString("chartpostformfieldname"),
 		ProvPostFormFieldName:  conf.GetString("provpostformfieldname"),
 		ContextPath:            conf.GetString("contextpath"),
-		LogJSON:                conf.GetBool("logjson"),
 		LogHealth:              conf.GetBool("loghealth"),
 		LogLatencyInteger:      conf.GetBool("loglatencyinteger"),
-		Debug:                  conf.GetBool("debug"),
 		EnableAPI:              !conf.GetBool("disableapi"),
 		DisableDelete:          conf.GetBool("disabledelete"),
 		UseStatefiles:          !conf.GetBool("disablestatefiles"),
@@ -96,7 +106,7 @@ func cliHandler(c *cli.Context) {
 		AuthRealm:              conf.GetString("authrealm"),
 		AuthService:            conf.GetString("authservice"),
 		AuthCertPath:           conf.GetString("authcertpath"),
-		AuthActionsSearchPath: 	conf.GetString("authactionssearchpath"),
+		AuthActionsSearchPath:  conf.GetString("authactionssearchpath"),
 		DepthDynamic:           conf.GetBool("depthdynamic"),
 		CORSAllowOrigin:        conf.GetString("cors.alloworigin"),
 		WriteTimeout:           conf.GetInt("writetimeout"),

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -33,6 +33,7 @@ type (
 		StorageBackend         storage.Backend
 		ExternalCacheStore     cache.Store
 		TimestampTolerance     time.Duration
+		Logger                 *cm_logger.Logger
 		ChartURL               string
 		TlsCert                string
 		TlsKey                 string
@@ -67,11 +68,11 @@ type (
 		CORSAllowOrigin        string
 		ReadTimeout            int
 		WriteTimeout           int
-		// EnforceSemver was deprecated, see https://github.com/helm/chartmuseum/issues/485 for more info
+		CacheInterval          time.Duration
+		Host                   string
+		Version                string
+		// Deprecated: see https://github.com/helm/chartmuseum/issues/485 for more info
 		EnforceSemver2 bool
-		CacheInterval  time.Duration
-		Host           string
-		Version        string
 	}
 
 	// Server is a generic interface for web servers
@@ -82,21 +83,13 @@ type (
 
 // NewServer creates a new Server instance
 func NewServer(options ServerOptions) (Server, error) {
-	logger, err := cm_logger.NewLogger(cm_logger.LoggerOptions{
-		Debug:   options.Debug,
-		LogJSON: options.LogJSON,
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	contextPath := strings.TrimSuffix(options.ContextPath, "/")
 	if contextPath != "" && !strings.HasPrefix(contextPath, "/") {
 		contextPath = "/" + contextPath
 	}
 
 	router := cm_router.NewRouter(cm_router.RouterOptions{
-		Logger:                logger,
+		Logger:                options.Logger,
 		LogLatencyInteger:     options.LogLatencyInteger,
 		Username:              options.Username,
 		Password:              options.Password,
@@ -122,7 +115,7 @@ func NewServer(options ServerOptions) (Server, error) {
 	})
 
 	server, err := mt.NewMultiTenantServer(mt.MultiTenantServerOptions{
-		Logger:                 logger,
+		Logger:                 options.Logger,
 		Router:                 router,
 		StorageBackend:         options.StorageBackend,
 		ExternalCacheStore:     options.ExternalCacheStore,

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -43,10 +43,8 @@ type (
 		ChartPostFormFieldName string
 		ProvPostFormFieldName  string
 		ContextPath            string
-		LogJSON                bool
 		LogHealth              bool
 		LogLatencyInteger      bool
-		Debug                  bool
 		EnableAPI              bool
 		UseStatefiles          bool
 		AllowOverwrite         bool
@@ -73,6 +71,10 @@ type (
 		Version                string
 		// Deprecated: see https://github.com/helm/chartmuseum/issues/485 for more info
 		EnforceSemver2 bool
+		// Deprecated: Debug is no longer effective. ServerOptions now requires the Logger field to be set and configured with LoggerOptions accordingly.
+		Debug bool
+		// Deprecated: LogJSON is no longer effective. ServerOptions now requires the Logger field to be set and configured with LoggerOptions accordingly.
+		LogJSON bool
 	}
 
 	// Server is a generic interface for web servers

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -58,7 +58,6 @@ type (
 		APIEnabled             bool
 		DisableDelete          bool
 		UseStatefiles          bool
-		EnforceSemver2         bool
 		ChartURL               string
 		ChartPostFormFieldName string
 		ProvPostFormFieldName  string
@@ -68,6 +67,8 @@ type (
 		TenantCacheKeyLock     *sync.Mutex
 		CacheInterval          time.Duration
 		EventChan              chan event
+		// Deprecated: see https://github.com/helm/chartmuseum/issues/485 for more info
+		EnforceSemver2 bool
 	}
 
 	// MultiTenantServerOptions are options for constructing a MultiTenantServer
@@ -89,8 +90,9 @@ type (
 		EnableAPI              bool
 		DisableDelete          bool
 		UseStatefiles          bool
-		EnforceSemver2         bool
 		CacheInterval          time.Duration
+		// Deprecated: see https://github.com/helm/chartmuseum/issues/485 for more info
+		EnforceSemver2 bool
 	}
 
 	tenantInternals struct {

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/chartmuseum/storage"
+	cm_logger "helm.sh/chartmuseum/pkg/chartmuseum/logger"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -45,8 +46,14 @@ func (suite *ServerTestSuite) TearDownSuite() {
 }
 
 func (suite *ServerTestSuite) TestNewServer() {
+	log, err := cm_logger.NewLogger(cm_logger.LoggerOptions{
+		Debug:   true,
+		LogJSON: true,
+	})
+	suite.Nil(err, "no error creating logger")
 	serverOptions := ServerOptions{
 		StorageBackend: suite.Backend,
+		Logger:         log,
 	}
 
 	multiTenantServer, err := NewServer(serverOptions)

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -24,9 +24,10 @@ import (
 
 type (
 	configVar struct {
-		Type    configVarType
-		Default interface{}
-		CLIFlag cli.Flag
+		Type       configVarType
+		Default    interface{}
+		CLIFlag    cli.Flag
+		Deprecated bool
 	}
 
 	configVarType string
@@ -756,6 +757,7 @@ var configVars = map[string]configVar{
 			Usage:  "(deprecated) enforce the chart museum server only accepts the valid chart version as Helm does",
 			EnvVar: "ENFORCE_SEMVER2",
 		},
+		Deprecated: true,
 	},
 	"cacheinterval": {
 		Type:    durationType,


### PR DESCRIPTION
A follow up on https://github.com/helm/chartmuseum/pull/522 to print warnings if deprecated options are being set.

Admittedly, I haven't added unit tests around this yet as that required some refactors around how the configuration code works right now (a lot of the configuration relies on variables that aren't easily overridden). I can come back and handle that if this approach seems good!

It seemed the best way to approach this was to create the logger earlier on, though I didn't pull `Debug` and `LogJSON` out of the `ServerOptions` struct just in case for some reason these are being used by someone (seems unlikely).