### PR TITLE
Generate SPDX SBOM at release time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
         uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
         with:
           cosign-release: 'v1.5.0'
+      - name: Install Kubernetes SBOM Tool
+        uses: puerco/bom-installer@aa0837e37b6965b5fc50adfad0683ec3c0a2c2c4
       - name: Release artifacts
         id: release-artifacts
         env:
@@ -94,6 +96,13 @@ jobs:
         if: always()
         run: |
           rm -f ${HOME}/.docker/config.json
+      - name: generate release sbom 
+        id: SBOM
+        env:
+          RELEASE: "${{ steps.prepare.outputs.version }}" 
+        run: |
+          ./scripts/sbom.sh
+          cosign attach sbom --sbom _dist/chartmuseum-${{ steps.prepare.outputs.version }}.spdx ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
       - name: upload coverage report
         uses: actions/upload-artifact@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,20 +47,6 @@ jobs:
           echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} \
             --build-arg revision=$(git rev-parse --short HEAD) \
             ${TAGS} .
-      - name: Install sigstore cosign
-        uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
-        with:
-          cosign-release: 'v1.5.0'
-      - name: Install Kubernetes SBOM Tool
-        uses: puerco/bom-installer@aa0837e37b6965b5fc50adfad0683ec3c0a2c2c4
-      - name: Release artifacts
-        id: release-artifacts
-        env:
-          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
-          AZURE_STORAGE_CONTAINER_NAME: ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          VERSION="${{ steps.prepare.outputs.version }}" ./scripts/release-artifacts.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -84,25 +70,37 @@ jobs:
       - name: Docker Buildx (push)
         run: |
           docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
-      - name: Sign the published Docker images (via GitHub OIDC token)
+      - name: Docker Check Manifest
+        run: |
+          docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+      - name: Install Kubernetes SBOM Tool
+        uses: puerco/bom-installer@aa0837e37b6965b5fc50adfad0683ec3c0a2c2c4
+      - name: Install sigstore cosign
+        uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
+        with:
+          cosign-release: 'v1.5.0'
+      - name: Release artifacts (includes SBOM and signatures)
+        id: release-artifacts
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
+          AZURE_STORAGE_CONTAINER_NAME: ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          VERSION="${{ steps.prepare.outputs.version }}" ./scripts/release-artifacts.sh
+      - name: Sign the published images (via GitHub OIDC token)
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
           cosign sign ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
-      - name: Docker Check Manifest
+      - name: Attach SBOM to published images
+        env:
+          COSIGN_EXPERIMENTAL: "true"
         run: |
-          docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+          cosign attach sbom --sbom _dist/chartmuseum-${{ steps.prepare.outputs.version }}.spdx ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
       - name: Clear
         if: always()
         run: |
           rm -f ${HOME}/.docker/config.json
-      - name: generate release sbom 
-        id: SBOM
-        env:
-          RELEASE: "${{ steps.prepare.outputs.version }}" 
-        run: |
-          ./scripts/sbom.sh
-          cosign attach sbom --sbom _dist/chartmuseum-${{ steps.prepare.outputs.version }}.spdx ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
       - name: upload coverage report
         uses: actions/upload-artifact@main
         with:

--- a/Makefile
+++ b/Makefile
@@ -174,14 +174,18 @@ fetch-dist:
 #   shasum -a 256 -c chartmuseum-v0.13.1-darwin-amd64.tar.gz.sha256sum
 .PHONY: checksum
 checksum:
-	for f in $$(ls _dist/*.{gz,zip} 2>/dev/null) ; do \
+	for f in $$(ls _dist/*.{gz,spdx,zip} 2>/dev/null) ; do \
 		echo "Creating $${f}.sha256sum" ; \
 		shasum -a 256 "$${f}" | sed 's/_dist\///' > "$${f}.sha256sum" ; \
 	done
 
+.PHONY: sbom
+sbom:
+	@./scripts/sbom.sh
+
 .PHONY: cosign
 cosign:
-	for f in $$(ls _dist/*.{gz,zip,sha256sum} 2>/dev/null) ; do \
+	for f in $$(ls _dist/*.{gz,zip,sha256sum,spdx} 2>/dev/null) ; do \
 		echo "Creating $${f}.sig" ; \
 		cosign sign-blob --output-file "$${f}.sig" "$${f}"; \
 	done

--- a/scripts/release-artifacts.sh
+++ b/scripts/release-artifacts.sh
@@ -28,7 +28,7 @@ sudo apt install azure-cli
 
 echo "Building chartmuseum binaries"
 make build-cross
-make dist checksum cosign VERSION="${VERSION}"
+make dist sbom checksum cosign VERSION="${VERSION}"
 
 echo "Pushing binaries to Azure"
 az storage blob upload-batch -s _dist/ -d "$AZURE_STORAGE_CONTAINER_NAME" --pattern 'chartmuseum-*' --connection-string "$AZURE_STORAGE_CONNECTION_STRING"

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -89,6 +89,8 @@ Download ChartMuseum ${RELEASE}. The common platform binaries are here:
 - [Linux s390x](https://get.helm.sh/chartmuseum-${RELEASE}-linux-s390x.tar.gz) ([archive sig](https://get.helm.sh/chartmuseum-${RELEASE}-linux-s390x.tar.gz.sig) / [checksum](https://get.helm.sh/chartmuseum-${RELEASE}-linux-s390x.tar.gz.sha256sum) / [checksum sig](https://get.helm.sh/chartmuseum-${RELEASE}-linux-s390x.tar.gz.sha256sum.sig) / $(cat _dist/chartmuseum-${RELEASE}-linux-s390x.tar.gz.sha256sum | awk '{print $1}'))
 - [Windows amd64](https://get.helm.sh/chartmuseum-${RELEASE}-windows-amd64.zip) ([archive sig](https://get.helm.sh/chartmuseum-${RELEASE}-windows-amd64.zip.sig) / [checksum](https://get.helm.sh/chartmuseum-${RELEASE}-windows-amd64.zip.sha256sum) / [checksum sig](https://get.helm.sh/chartmuseum-${RELEASE}-windows-amd64.zip.sha256sum.sig) / $(cat _dist/chartmuseum-${RELEASE}-windows-amd64.zip.sha256sum | awk '{print $1}'))
 
+You can download the SBOM for this release in SPDX format [here](https://get.helm.sh/chartmuseum-${RELEASE}.spdx).
+
 You can use a [script to install](https://raw.githubusercontent.com/helm/chartmuseum/main/scripts/get-chartmuseum) on any system with \`bash\`.
 
 ## What's Next

--- a/scripts/sbom.sh
+++ b/scripts/sbom.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+RELEASE=${RELEASE:-$2}
+
+cd _dist
+
+# Initialize the configuration file
+cat << EOF > .sbom.yaml
+---
+namespace: https://get.helm.sh/chartmuseum-${RELEASE}.spdx
+license: Apache-2.0
+name: ChartMuseum
+artifacts:
+  - type: directory
+    source: ..
+EOF
+
+for file in $(ls *.{gz,zip}); 
+    do echo "Adding ${file} to SBOM"
+    echo "  - type: file"  >> .sbom.yaml
+    echo "    source: ${file}" >> .sbom.yaml
+done
+
+echo "Adding image ghcr.io/helm/chartmuseum:${RELEASE}"
+echo "  - type: image" >> .sbom.yaml
+echo "    source: ghcr.io/helm/chartmuseum:${RELEASE}" >> .sbom.yaml
+
+echo "Wrote configuration file:"
+cat .sbom.yaml
+
+bom generate -c .sbom.yaml -o chartmuseum-${RELEASE}.spdx
+
+echo "SBOM written to _dist/chartmuseum-${RELEASE}.spdx"
+rm .sbom.yaml
+

--- a/scripts/sbom.sh
+++ b/scripts/sbom.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
-RELEASE=${RELEASE:-$2}
+set -euo pipefail
+: ${VERSION:?"VERSION environment variable is not set"}
 
-cd _dist
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR/../
+mkdir -p ./_dist/
+pushd ./_dist/
 
 # Initialize the configuration file
 cat << EOF > .sbom.yaml
@@ -21,15 +25,15 @@ for file in $(ls *.{gz,zip});
     echo "    source: ${file}" >> .sbom.yaml
 done
 
-echo "Adding image ghcr.io/helm/chartmuseum:${RELEASE}"
+echo "Adding image ghcr.io/helm/chartmuseum:${VERSION}"
 echo "  - type: image" >> .sbom.yaml
-echo "    source: ghcr.io/helm/chartmuseum:${RELEASE}" >> .sbom.yaml
+echo "    source: ghcr.io/helm/chartmuseum:${VERSION}" >> .sbom.yaml
 
 echo "Wrote configuration file:"
 cat .sbom.yaml
 
-bom generate -c .sbom.yaml -o chartmuseum-${RELEASE}.spdx
+bom generate -c .sbom.yaml -o chartmuseum-${VERSION}.spdx
 
-echo "SBOM written to _dist/chartmuseum-${RELEASE}.spdx"
 rm .sbom.yaml
-
+popd
+echo "SBOM written to _dist/chartmuseum-${VERSION}.spdx"


### PR DESCRIPTION
This PR adds the Kubernetes SBOM tool to the release workflow to generate a Software Bill of Materials.

There are two parts to achieve this, each split into a commit in the PR:

1. The actions workflow now uses the new [`bom-installer`](https://github.com/puerco/bom-installer) action to install bom into the runner.
2. The actual SBOM generation is done by a new script in `scripts/sbom.sh` that reads the artifacts and generates the SBOM including a) the source code and dependencies b) the container image c) the built tarballs.

/cc: @jdolitsky 

Fixes #537 

#### TODO: 

The current change only writes the SBOM. It should then be stored in its final location

#### Structure

This is a sample visualization of the generated SBOM:

![image](https://user-images.githubusercontent.com/3935899/151687589-52381fb8-3e89-4300-be2d-9400593d6229.png)
