### PR TITLE
fix: avoid panic with dynamic depth configured

### DIFF
--- a/pkg/chartmuseum/router/match.go
+++ b/pkg/chartmuseum/router/match.go
@@ -101,6 +101,9 @@ func match(routes []*Route, method string, url string, contextPath string, depth
 			}
 		}
 	}
+	if depth < 0 {
+		return nil, nil
+	}
 
 	if len(pathSplit) >= depth+startIndex {
 		repoParts := pathSplit[startIndex : depth+startIndex]

--- a/pkg/chartmuseum/router/match_test.go
+++ b/pkg/chartmuseum/router/match_test.go
@@ -70,7 +70,6 @@ func (suite *MatchTestSuite) TestMatch() {
 		}
 
 		for _, contextPath := range []string{"", "/x", "/x/y", "/x/y/z"} {
-
 			// GET /
 			r := pathutil.Join("/", contextPath)
 			route, params := match(routes, "GET", r, contextPath, depth, false)
@@ -86,6 +85,12 @@ func (suite *MatchTestSuite) TestMatch() {
 			val, exists := c.Get("index")
 			suite.True(exists)
 			suite.Equal(0, val)
+
+			// GET /favicon
+			// This route should not exist and not cause a panic with dynamic depth enabled
+			r = pathutil.Join("/", contextPath, "favicon")
+			routeWithDepthDynamic, paramsWithDepthDynamic = match(routes, "GET", r, contextPath, 0, true)
+			suite.Nil(routeWithDepthDynamic)
 
 			// GET /health
 			r = pathutil.Join("/", contextPath, "health")


### PR DESCRIPTION
Fixes #443. 

In the case where depth = -1, I think we can assume the url didn't match any of the routes and thus doesn't exist. I went through a few cases and this seems like the desired behavior but I had a hard time understanding this entire flow. This did end up fixing the panics caused by routes that aren't matched with anything i.e `/favicon`. I also tested a few scenarios using dynamic depth and everything looked to behave correctly. 