### PR TITLE
ci: move building the go binaries outside of the Docker image to speed up builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,9 +2,6 @@
 
 *
 
-# Bring in our source code and dependency listings
+# Bring in our binary
 
-!go.mod
-!go.sum
-!cmd/**
-!pkg/**
+!_dist/linux-*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
         run: make bootstrap
       - name: run unit tests
         run: make test
-      - name: build binary
-        run: make build-linux
+      - name: build binaries
+        run: make build-cross
       - name: run acceptance tests
         run: sudo pip install virtualenv && make acceptance
       - name: Prepare
@@ -58,18 +58,15 @@ jobs:
           version: latest
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
-      - name: Docker Buildx (build)
-        run: |
-          docker buildx build --no-cache --pull --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
       - name: Docker Login
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker Buildx (push)
+      - name: Docker Buildx (build and push)
         run: |
-          docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
+          docker buildx build --no-cache --pull --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
       - name: Docker Check Manifest
         run: |
           docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
@@ -86,7 +83,7 @@ jobs:
           AZURE_STORAGE_CONTAINER_NAME: ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          VERSION="${{ steps.prepare.outputs.version }}" ./scripts/release-artifacts.sh
+          SKIP_BUILD=true VERSION="${{ steps.prepare.outputs.version }}" ./scripts/release-artifacts.sh
       - name: Sign the published images (via GitHub OIDC token)
         env:
           COSIGN_EXPERIMENTAL: "true"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,12 @@
-# This will be our builder image
-
-FROM golang:alpine
-
-ARG version=0.14.0
-
-ARG revision=main
-
-COPY . /go/src/github.com/helm/chartmuseum
-
-WORKDIR /go/src/github.com/helm/chartmuseum
-
-RUN CGO_ENABLED=0 GO111MODULE=on go build \
-   -v --ldflags="-w -X main.Version=${version} -X main.Revision=${revision}" \
-   -o /chartmuseum \
-   cmd/chartmuseum/main.go
-
-
-# This will be the final image
-
 FROM alpine:latest
+
+# TARGETARCH is predefined by Docker
+# See https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETARCH
 
 RUN apk add --no-cache cifs-utils ca-certificates
 
-COPY --from=0 /chartmuseum /chartmuseum
+COPY ./_dist/linux-$TARGETARCH/chartmuseum /chartmuseum
 
 USER 1000:1000
 

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -37,7 +37,7 @@ else
     PLATFORM="linux"
 fi
 
-export PATH="$PWD/testbin:$PWD/bin/$PLATFORM/$ARCH:$PATH"
+export PATH="$PWD/testbin:$PWD/bin/$PLATFORM/$ARCH:$PWD/_dist/$PLATFORM-$ARCH:$PATH"
 
 mkdir -p .robot/
 

--- a/scripts/release-artifacts.sh
+++ b/scripts/release-artifacts.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 : ${AZURE_STORAGE_CONNECTION_STRING:?"AZURE_STORAGE_CONNECTION_STRING environment variable is not set"}
 : ${AZURE_STORAGE_CONTAINER_NAME:?"AZURE_STORAGE_CONTAINER_NAME environment variable is not set"}
 : ${VERSION:?"VERSION environment variable is not set"}
+# SKIP_BUILD is used in CI since make build-cross is ran prior to this script in order for other steps to reuse the build artifacts
+SKIP_BUILD=${SKIP_BUILD:-false}
 
 echo "Installing Azure CLI"
 echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
@@ -26,8 +28,12 @@ sudo apt install apt-transport-https
 sudo apt update
 sudo apt install azure-cli
 
-echo "Building chartmuseum binaries"
-make build-cross
+if ! ${SKIP_BUILD}
+then
+    echo "Building chartmuseum binaries"
+    make build-cross
+fi
+
 make dist sbom checksum cosign VERSION="${VERSION}"
 
 echo "Pushing binaries to Azure"


### PR DESCRIPTION
Related to #539. I tested this locally as much as possible using `act` with some of the build steps commented out.

This commit moves the building of the chartmuseum binaries out of the Docker image and uses `make build-cross` early on in the job to build all the binaries. Then the Docker image will copy in the proper binary based on the `TARGETARCH` build arg.

Building the images is now super quick, although some of that time was moved to the `make build-cross` step. However, now we only have to download go modules once instead of N number of times (where N = number of architectures).

I also combined the build and push steps since it seemed like an innocent change (like @jdolitsky mentioned in the issue) 🤞.
