### PR TITLE
fix: Use the github API to get the latest release version

### DIFF
--- a/scripts/get-chartmuseum
+++ b/scripts/get-chartmuseum
@@ -104,11 +104,11 @@ verifySupported() {
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
     # Get tag from release URL
-    local latest_release_url="https://github.com/helm/chartmuseum/releases"
+    local latest_release_url="https://api.github.com/repos/helm/chartmuseum/releases/latest"
     if [ "${HAS_CURL}" == "true" ]; then
-      TAG=$(curl -Ls $latest_release_url | grep 'href="/helm/chartmuseum/releases/tag/v0.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+      TAG=$(curl -Ls $latest_release_url | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
     elif [ "${HAS_WGET}" == "true" ]; then
-      TAG=$(wget $latest_release_url -O - 2>&1 | grep 'href="/helm/chartmuseum/releases/tag/v0.[0-9]*.[0-9]*\"' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}')
+      TAG=$(wget $latest_release_url -O - 2>&1 | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
     fi
   else
     TAG=$DESIRED_VERSION


### PR DESCRIPTION
https://github.com/helm/chartmuseum/issues/552

The script was pulling `true` as the latest release version (i think the HTML changed). Instead of parsing the HTML, this changes the script to parse the JSON response from the API instead. 

I still need to look into gofish after this.