### PR TITLE
feat: customize welcome page

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,25 @@ scripts/mirror-k8s-repos.sh
 chartmuseum --debug --port=8080 --storage="local" --storage-local-rootdir="./mirror"
  ```
 
+## Custom Welcome Page
+
+With the flag `--web-template-path=<path>`, you can specify the path to your custom welcome page.
+
+The structure of the folder should be like this:
+
+```bash
+web/
+  index.html
+  xyz.html
+  static/
+      main.css
+      main.js
+```
+
+> ChartMuseum is using gin-gonic to serve the static files, this means that you can use go-template to render the files.
+
+If you don't specify a custom welcome page, ChartMuseum will serve the default one.
+
 ## Original Logo
 
 <sub>**_"Preserve your precious artifacts... in the cloud!"_**<sub>

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -115,6 +115,7 @@ func cliHandler(c *cli.Context) {
 		CacheInterval:          conf.GetDuration("cacheinterval"),
 		Host:                   conf.GetString("listen.host"),
 		PerChartLimit:          conf.GetInt("per-chart-limit"),
+		WebTemplatePath:        conf.GetString("web-template-path"),
 	}
 
 	server, err := newServer(options)

--- a/pkg/chartmuseum/router/match.go
+++ b/pkg/chartmuseum/router/match.go
@@ -74,6 +74,13 @@ func match(routes []*Route, method string, url string, contextPath string, depth
 			}
 		}
 	}
+	if checkStaticRoute(url) && method == http.MethodGet {
+		for _, route := range routes {
+			if checkStaticRoute(route.Path) {
+				return route, nil
+			}
+		}
+	}
 
 	isApiRoute := checkApiRoute(url)
 	if isApiRoute {
@@ -153,6 +160,10 @@ func match(routes []*Route, method string, url string, contextPath string, depth
 	}
 
 	return nil, nil
+}
+
+func checkStaticRoute(url string) bool {
+	return strings.HasPrefix(url, "/static")
 }
 
 func checkApiRoute(url string) bool {

--- a/pkg/chartmuseum/router/match_test.go
+++ b/pkg/chartmuseum/router/match_test.go
@@ -35,7 +35,7 @@ func (suite *MatchTestSuite) TestMatch() {
 
 	handlers := []gin.HandlerFunc{}
 
-	for i := 0; i <= 9; i++ {
+	for i := 0; i <= 10; i++ {
 		{
 			j := i
 			handlers = append(handlers, func(c *gin.Context) {
@@ -55,6 +55,7 @@ func (suite *MatchTestSuite) TestMatch() {
 		{"POST", "/api/:repo/charts", handlers[7], cm_auth.PushAction},
 		{"POST", "/api/:repo/prov", handlers[8], cm_auth.PushAction},
 		{"DELETE", "/api/:repo/charts/:name/:version", handlers[9], cm_auth.PushAction},
+		{"GET", "/static", handlers[10], cm_auth.PullAction},
 	}
 
 	for depth := 0; depth <= 3; depth++ {
@@ -235,6 +236,22 @@ func (suite *MatchTestSuite) TestMatch() {
 			suite.True(exists)
 			suite.Equal(9, val)
 			suite.Equal([]gin.Param{{"name", "mychart"}, {"version", "0.1.0"}, {"repo", repo}}, params)
+
+			// GET /static
+			r = pathutil.Join("/", contextPath, "static/main.css")
+			route, params = match(routes, "GET", r, contextPath, depth, false)
+			routeWithDepthDynamic, paramsWithDepthDynamic = match(routes, "GET", r, contextPath, 0, true)
+			suite.Equal(route, routeWithDepthDynamic)
+			suite.Equal(params, paramsWithDepthDynamic)
+
+			suite.NotNil(route)
+			suite.Nil(params)
+			if route != nil {
+				route.Handler(c)
+			}
+			val, exists = c.Get("index")
+			suite.True(exists)
+			suite.Equal(10, val)
 		}
 	}
 

--- a/pkg/chartmuseum/router/router.go
+++ b/pkg/chartmuseum/router/router.go
@@ -50,6 +50,7 @@ type (
 		ReadTimeout     time.Duration
 		WriteTimeout    time.Duration
 		Host            string
+		WebTemplatePath string
 	}
 
 	// RouterOptions are options for constructing a Router

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -69,6 +69,7 @@ type (
 		CacheInterval          time.Duration
 		Host                   string
 		Version                string
+		WebTemplatePath        string
 		// PerChartLimit allow museum server to keep max N version Charts
 		// And avoid swelling too large(if so , the index genertion will become slow)
 		PerChartLimit int
@@ -141,7 +142,8 @@ func NewServer(options ServerOptions) (Server, error) {
 		PerChartLimit:          options.PerChartLimit,
 		// Deprecated options
 		// EnforceSemver2 - see https://github.com/helm/chartmuseum/issues/485 for more info
-		EnforceSemver2: options.EnforceSemver2,
+		EnforceSemver2:  options.EnforceSemver2,
+		WebTemplatePath: options.WebTemplatePath,
 	})
 
 	return server, err

--- a/pkg/chartmuseum/server/multitenant/handlers_test.go
+++ b/pkg/chartmuseum/server/multitenant/handlers_test.go
@@ -1,0 +1,129 @@
+package multitenant
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/chartmuseum/storage"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/suite"
+	cm_logger "helm.sh/chartmuseum/pkg/chartmuseum/logger"
+	cm_router "helm.sh/chartmuseum/pkg/chartmuseum/router"
+)
+
+type HandlerTestSuite struct {
+	suite.Suite
+	ServerDepth0  *MultiTenantServer
+	TempDirectory string
+}
+
+func (suite *HandlerTestSuite) getServer(depth int) *MultiTenantServer {
+	logger, err := cm_logger.NewLogger(cm_logger.LoggerOptions{
+		Debug: true,
+	})
+	suite.Nil(err, "no error creating logger")
+
+	backend := storage.Backend(storage.NewLocalFilesystemBackend(os.TempDir()))
+	router := cm_router.NewRouter(cm_router.RouterOptions{
+		Logger:        logger,
+		Depth:         depth,
+		EnableMetrics: true,
+		MaxUploadSize: maxUploadSize,
+	})
+	serverDepth, err := NewMultiTenantServer(MultiTenantServerOptions{
+		Logger:                 logger,
+		Router:                 router,
+		StorageBackend:         backend,
+		TimestampTolerance:     time.Duration(0),
+		EnableAPI:              true,
+		ChartPostFormFieldName: "chart",
+		ProvPostFormFieldName:  "prov",
+		IndexLimit:             1,
+	})
+	return serverDepth
+}
+
+func (suite *HandlerTestSuite) TestCustomStaticFilesHandler() {
+	recorder := httptest.NewRecorder()
+	testContext, _ := gin.CreateTestContext(recorder)
+	testContext.Request, _ = http.NewRequest("GET", "/static/main.css", nil)
+	suite.ServerDepth0 = suite.getServer(0)
+	suite.ServerDepth0.WebTemplatePath = "testdata/template"
+	suite.ServerDepth0.getStaticFilesHandler(testContext)
+	data, err := os.ReadFile("testdata/template/static/main.css")
+	if err != nil {
+		suite.Fail("could not read testdata/template/static/main.css")
+	}
+	suite.Equal(200, recorder.Result().StatusCode)
+	suite.Equal("text/css; charset=utf-8", recorder.Header().Get("Content-Type"))
+	suite.Equal(string(data), recorder.Body.String())
+}
+
+func (suite *HandlerTestSuite) TestDefaultStaticFilesHandler() {
+	recorder := httptest.NewRecorder()
+	testContext, _ := gin.CreateTestContext(recorder)
+	testContext.Request, _ = http.NewRequest("GET", "/static/main.css", nil)
+	suite.ServerDepth0 = suite.getServer(0)
+	suite.ServerDepth0.getStaticFilesHandler(testContext)
+	suite.Equal(200, recorder.Result().StatusCode)
+	suite.Equal("", recorder.Header().Get("Content-Type"))
+}
+
+func (suite *HandlerTestSuite) TestCustomWelcomePage() {
+	recorder := httptest.NewRecorder()
+	testContext, engine := gin.CreateTestContext(recorder)
+
+	testContext.Request, _ = http.NewRequest("GET", "/", nil)
+	suite.ServerDepth0 = suite.getServer(0)
+	suite.ServerDepth0.WebTemplatePath = "testdata/template"
+	suite.ServerDepth0.Router.Engine = engine
+	suite.ServerDepth0.Router.LoadHTMLGlob(fmt.Sprintf("%s/*.html", suite.ServerDepth0.WebTemplatePath))
+	suite.ServerDepth0.getWelcomePageHandler(testContext)
+	data, err := os.ReadFile("testdata/template/index.html")
+	if err != nil {
+		suite.Fail("could not read testdata/template/index.html")
+	}
+	suite.Equal(200, recorder.Result().StatusCode)
+	suite.Equal("text/html; charset=utf-8", recorder.Header().Get("Content-Type"))
+	suite.Equal(string(data), recorder.Body.String())
+}
+
+func (suite *HandlerTestSuite) TestDefaultWelcomePage() {
+	recorder := httptest.NewRecorder()
+	testContext, _ := gin.CreateTestContext(recorder)
+	testContext.Request, _ = http.NewRequest("GET", "/", nil)
+	suite.ServerDepth0 = suite.getServer(0)
+	suite.ServerDepth0.getWelcomePageHandler(testContext)
+	data, err := os.ReadFile("testdata/default/index.html")
+	if err != nil {
+		suite.Fail("could not read testdata/default/index.html")
+	}
+	suite.Equal(200, recorder.Result().StatusCode)
+	suite.Equal("text/html", recorder.Header().Get("Content-Type"))
+	suite.Equal(string(data), recorder.Body.String())
+}
+
+func (suite *HandlerTestSuite) TestMissingTemplatesWelcomePage() {
+	recorder := httptest.NewRecorder()
+	testContext, engine := gin.CreateTestContext(recorder)
+	testContext.Request, _ = http.NewRequest("GET", "/", nil)
+	suite.ServerDepth0 = suite.getServer(0)
+	suite.ServerDepth0.WebTemplatePath = "testdata/dummy"
+	suite.ServerDepth0.Router.Engine = engine
+	suite.ServerDepth0.getWelcomePageHandler(testContext)
+	data, err := os.ReadFile("testdata/default/index.html")
+	if err != nil {
+		suite.Fail("could not read testdata/default/index.html")
+	}
+	suite.Equal(200, recorder.Result().StatusCode)
+	suite.Equal("text/html", recorder.Header().Get("Content-Type"))
+	suite.Equal(string(data), recorder.Body.String())
+}
+
+func TestHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(HandlerTestSuite))
+}

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -17,9 +17,8 @@ limitations under the License.
 package multitenant
 
 import (
-	cm_router "helm.sh/chartmuseum/pkg/chartmuseum/router"
-
 	cm_auth "github.com/chartmuseum/auth"
+	cm_router "helm.sh/chartmuseum/pkg/chartmuseum/router"
 )
 
 func (s *MultiTenantServer) Routes() []*cm_router.Route {
@@ -48,6 +47,15 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 
 	routes = append(routes, serverInfoRoutes...)
 	routes = append(routes, helmChartRepositoryRoutes...)
+
+	if s.WebTemplatePath != "" {
+		routes = append(routes, &cm_router.Route{
+			Method:  "GET",
+			Path:    "/static",
+			Handler: s.getStaticFilesHandler,
+			Action:  cm_auth.PullAction,
+		})
+	}
 
 	if s.APIEnabled {
 		routes = append(routes, chartManipulationRoutes...)

--- a/pkg/chartmuseum/server/multitenant/testdata/default/index.html
+++ b/pkg/chartmuseum/server/multitenant/testdata/default/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to ChartMuseum!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to ChartMuseum!</h1>
+<p>If you see this page, the ChartMuseum web server is successfully installed and
+working.</p>
+
+<p>For online documentation and support please refer to the
+<a href="https://github.com/helm/chartmuseum">GitHub project</a>.<br/>
+
+<p><em>Thank you for using ChartMuseum.</em></p>
+</body>
+</html>

--- a/pkg/chartmuseum/server/multitenant/testdata/template/index.html
+++ b/pkg/chartmuseum/server/multitenant/testdata/template/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<html><head>
+    <title>Welcome to ChartMuseum!</title>
+    <link href="/static/main.css" rel="stylesheet">
+</head>
+
+
+<body>
+<h1>Welcome to ChartMuseum - Template!</h1>
+<p>If you see this page, the ChartMuseum web server is successfully installed and
+    working.</p>
+
+<p>For online documentation and support please refer to the
+    <a href="https://github.com/helm/chartmuseum">GitHub project</a>.<br>
+
+</p><p><em>Thank you for using ChartMuseum.</em></p>
+
+
+</body></html>
+</html>

--- a/pkg/chartmuseum/server/multitenant/testdata/template/static/main.css
+++ b/pkg/chartmuseum/server/multitenant/testdata/template/static/main.css
@@ -1,0 +1,108 @@
+html,
+body {
+    background-image: none !important;
+    background-color: rgba(40, 42, 54, 1) !important;
+    text-align: center;
+}
+
+body * {
+    color: rgba(248, 248, 242, 1) !important;
+    background-color: rgba(40, 42, 54, 1) !important;
+}
+
+a,
+a * {
+    color: rgba(80, 250, 123, 1) !important;
+    background-color: transparent !important;
+}
+
+a:hover,
+a:hover *,
+a:visited:hover,
+a:visited:hover *,
+span[onclick]:hover,
+div[onclick]:hover,
+[role="link"]:hover,
+[role="link"]:hover *,
+[role="button"]:hover *,
+[role="menuitem"]:hover,
+[role="menuitem"]:hover *,
+.link:hover,
+.link:hover * {
+    color: rgba(241, 250, 140, 1) !important;
+}
+
+a:visited,
+a:visited * {
+    color: rgba(98, 114, 164, 1) !important;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+strong,
+[id*="headline"],
+[class*="headline"],
+[id*="header"],
+[class*="header"],
+[class*="header"] td {
+    color: rgba(255, 184, 108, 1) !important;
+}
+
+table {
+    background-color: rgba(40, 42, 54, 1) !important;
+}
+
+[id*="overlay"],
+[id*="lightbox"],
+blockquote {
+    background-color: rgba(68, 71, 90, 1) !important;
+}
+
+pre,
+dl {
+    background-color: rgba(68, 71, 90, 1) !important;
+}
+
+input,
+select,
+button,
+[role="button"],
+a.button,
+a.submit,
+a.BigButton,
+a.TabLink,
+.install[onclick] {
+    text-indent: 5px;
+    appearance: none !important;
+    -moz-appearance: none !important;
+    -webkit-appearance: none !important;
+    background: rgba(68, 71, 90, 1) !important;
+}
+
+textarea {
+    appearance: none !important;
+    -moz-appearance: none !important;
+    -webkit-appearance: none !important;
+    background: rgba(68, 71, 90, 1) !important;
+}
+
+div,
+ul,
+li {
+    background-image: none !important;
+}
+
+a.highlight,
+a.highlight *,
+a.active,
+a.active *,
+.selected,
+.selected *,
+[href="#"] {
+    font-weight: bold !important;
+    color: rgba(139, 233, 253, 1) !important;
+}

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -796,6 +796,15 @@ var configVars = map[string]configVar{
 			EnvVar: "PER_CHART_LIMIT",
 		},
 	},
+	"web-template-path": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "web-template-path",
+			Usage:  "path to the folder, which contains the custom welcome page",
+			EnvVar: "WEB_TEMPLATE_PATH",
+		},
+	},
 }
 
 func populateCLIFlags() {


### PR DESCRIPTION
Fixes: #550

Hi,

this PR enables potential users to provide their own Welcome page. 

With the flag `--web-template-path=<path>`, you can specify the path to your custom welcome page.

The structure of the folder should be like this:

```bash
web/
  index.html
  xyz.html
  static/
      main.css
      main.js
```

I use `c.HTML` to serve the custom welcome page, this means we have full access to the go-template engine

The rules are: Every file with html ending will be picked up. This is useful if you want to create templates and include them in the main index.html file (see my example). But only the `index.html` will be served!

Static files (css, js or pics) should be saved into the `static` folder. I check the code, if the static folder if present to serve this.

> Currently, their is no support for variables in the template.

If everybody like this, I will extend the enable the helm chart too.

Example:
![image](https://user-images.githubusercontent.com/38325136/156899747-08dd4570-01c8-48fa-81b6-da96143cbe31.png)

Looking for your feedback!
