### PR TITLE
Fix : Call Update Metrics when founding existing index-cache.yaml

### DIFF
--- a/pkg/chartmuseum/server/multitenant/cache.go
+++ b/pkg/chartmuseum/server/multitenant/cache.go
@@ -460,12 +460,15 @@ func (server *MultiTenantServer) newRepositoryIndex(log cm_logger.LoggingFn, rep
 		"repo", repo,
 	)
 
-	return &cm_repo.Index{
+	index := &cm_repo.Index{
 		IndexFile: indexFile,
 		RepoName:  repo,
 		Raw:       object.Content,
 		ChartURL:  chartURL,
 	}
+	index.UpdateMetrics()
+
+	return index
 }
 
 func (server *MultiTenantServer) initCacheTimer() {

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -74,7 +74,7 @@ func (index *Index) Regenerate() error {
 		return err
 	}
 	index.Raw = raw
-	index.updateMetrics()
+	index.UpdateMetrics()
 	return nil
 }
 
@@ -146,7 +146,7 @@ func (index *Index) setChartURL(chartVersion *helm_repo.ChartVersion) {
 }
 
 // UpdateMetrics updates chart index-related Prometheus metrics
-func (index *Index) updateMetrics() {
+func (index *Index) UpdateMetrics() {
 	nChartVersions := 0
 	for _, chartVersions := range index.Entries {
 		nChartVersions += len(chartVersions)


### PR DESCRIPTION
Hi !

I have Chartmuseum deployed in a k8s cluster and connected to an Azure Blob Storage Backend.

When the remote index-cache.yaml is already present, metrics `charts_served_total` & `chart_versions_served_total` are not initialized, and the /metrics endpoint does not return those two metrics.

I suggest that if we found an index-cache.yaml when initializing cache entry, we force an "update metrics" on it.

Thank you !