### PR TITLE
fix: Add additional index locking

### DIFF
--- a/pkg/chartmuseum/server/multitenant/cache.go
+++ b/pkg/chartmuseum/server/multitenant/cache.go
@@ -155,6 +155,8 @@ func (server *MultiTenantServer) regenerateRepositoryIndexWorker(log cm_logger.L
 		ChartURL:  entry.RepoIndex.ChartURL,
 		IndexLock: sync.RWMutex{},
 	}
+	index.IndexLock.Lock()
+	defer index.IndexLock.Unlock()
 
 	for _, object := range diff.Removed {
 		err := server.removeIndexObject(log, repo, index, object)

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -50,7 +50,7 @@ type (
 		RepoName   string `json:"b"`
 		Raw        []byte `json:"c"`
 		ChartURL   string `json:"d"`
-		IndexLock sync.RWMutex
+		IndexLock  sync.RWMutex
 	}
 )
 
@@ -103,7 +103,7 @@ func (index *Index) AddEntry(chartVersion *helm_repo.ChartVersion) {
 	if _, ok := index.Entries[chartVersion.Name]; !ok {
 		index.Entries[chartVersion.Name] = helm_repo.ChartVersions{}
 	}
-	//
+
 	entries := index.Entries[chartVersion.Name]
 	l := len(entries)
 	for i := 1; i <= 5 && l-i >= 0; i++ {


### PR DESCRIPTION
This PR adds some additional locking of the index file while it is being updated to avoid races with API calls. 

I was able to reproduce https://github.com/helm/chartmuseum/issues/453 using the existing locust tests. I narrowed the issue down to things that operate on the index file and I saw  that as  `regenerateRepositoryIndexWorker` ran, it could cause issues with API calls that are also attempting to update the index file (like chart uploads and deletions).
