### PR TITLE
feat: Add support for hosting an artifacthub-repo.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,10 +667,15 @@ specified repo ID in the `repositoryID` field of the yaml file.
 repositoryID: The ID of the Artifact Hub repository where the packages will be published to (optional, but it enables verified publisher)
 ```
 
-ChartMuseum is currently limited to only supporting the `repositoryID` field and also only allows specifying **one**
-repo ID per ChartMuseum instance.
+##### Multitenancy
 
-This means multitenancy is currently not supported in this feature.
+For multitenancy setups, you can provide a key value pair to the flag in the format: `--artifact-hub-repo-id <repo>=<repo id>`
+
+```bash
+chartmuseum --storage local --storage-local-rootdir /tmp/ --depth 1 --artifact-hub-repo-id org1=<repo id> --artifact-hub-repo-id org2=<repo2 id>
+```
+
+The `artifacthub-repo.yml` file will then be served at `/org1/artifacthub-repo.yml` and `/org2/artifacthub-repo.yml`
 
 ## Original Logo
 

--- a/README.md
+++ b/README.md
@@ -658,6 +658,20 @@ web/
 
 If you don't specify a custom welcome page, ChartMuseum will serve the default one.
 
+#### Artifact Hub
+
+By setting the flag `--artifact-hub-repo-id <repo id>`, ChartMuseum will serve a `artifacthub-repo.yml` file with the
+specified repo ID in the `repositoryID` field of the yaml file.
+
+```yaml
+repositoryID: The ID of the Artifact Hub repository where the packages will be published to (optional, but it enables verified publisher)
+```
+
+ChartMuseum is currently limited to only supporting the `repositoryID` field and also only allows specifying **one**
+repo ID per ChartMuseum instance.
+
+This means multitenancy is currently not supported in this feature.
+
 ## Original Logo
 
 <sub>**_"Preserve your precious artifacts... in the cloud!"_**<sub>

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -116,6 +116,7 @@ func cliHandler(c *cli.Context) {
 		Host:                   conf.GetString("listen.host"),
 		PerChartLimit:          conf.GetInt("per-chart-limit"),
 		WebTemplatePath:        conf.GetString("web-template-path"),
+		ArtifactHubRepoID:      conf.GetString("artifact-hub-repo-id"),
 	}
 
 	server, err := newServer(options)

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/chartmuseum/storage"
+
 	"helm.sh/chartmuseum/pkg/cache"
 	"helm.sh/chartmuseum/pkg/chartmuseum"
 	cm_logger "helm.sh/chartmuseum/pkg/chartmuseum/logger"
@@ -116,7 +117,7 @@ func cliHandler(c *cli.Context) {
 		Host:                   conf.GetString("listen.host"),
 		PerChartLimit:          conf.GetInt("per-chart-limit"),
 		WebTemplatePath:        conf.GetString("web-template-path"),
-		ArtifactHubRepoID:      conf.GetString("artifact-hub-repo-id"),
+		ArtifactHubRepoID:      conf.GetStringMapString("artifact-hub-repo-id"),
 	}
 
 	server, err := newServer(options)

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -70,6 +70,7 @@ type (
 		Host                   string
 		Version                string
 		WebTemplatePath        string
+		ArtifactHubRepoID      string
 		// PerChartLimit allow museum server to keep max N version Charts
 		// And avoid swelling too large(if so , the index genertion will become slow)
 		PerChartLimit int
@@ -140,10 +141,11 @@ func NewServer(options ServerOptions) (Server, error) {
 		Version:                options.Version,
 		CacheInterval:          options.CacheInterval,
 		PerChartLimit:          options.PerChartLimit,
+		ArtifactHubRepoID:      options.ArtifactHubRepoID,
+		WebTemplatePath:        options.WebTemplatePath,
 		// Deprecated options
 		// EnforceSemver2 - see https://github.com/helm/chartmuseum/issues/485 for more info
-		EnforceSemver2:  options.EnforceSemver2,
-		WebTemplatePath: options.WebTemplatePath,
+		EnforceSemver2: options.EnforceSemver2,
 	})
 
 	return server, err

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/chartmuseum/storage"
+
 	"helm.sh/chartmuseum/pkg/cache"
 	cm_logger "helm.sh/chartmuseum/pkg/chartmuseum/logger"
 	cm_router "helm.sh/chartmuseum/pkg/chartmuseum/router"
@@ -70,7 +71,7 @@ type (
 		Host                   string
 		Version                string
 		WebTemplatePath        string
-		ArtifactHubRepoID      string
+		ArtifactHubRepoID      map[string]string
 		// PerChartLimit allow museum server to keep max N version Charts
 		// And avoid swelling too large(if so , the index genertion will become slow)
 		PerChartLimit int

--- a/pkg/chartmuseum/server/multitenant/artifacthub.go
+++ b/pkg/chartmuseum/server/multitenant/artifacthub.go
@@ -1,0 +1,43 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multitenant
+
+import (
+	"github.com/ghodss/yaml"
+	"net/http"
+
+	cm_logger "helm.sh/chartmuseum/pkg/chartmuseum/logger"
+	cm_repo "helm.sh/chartmuseum/pkg/repo"
+)
+
+const artifactHubFileContentType = "application/x-yaml"
+
+func (server *MultiTenantServer) getArtifactHubYml(log cm_logger.LoggingFn, repo string) ([]byte, *HTTPError) {
+	artifactHubFile := &cm_repo.ArtifactHubFile{
+		RepoID: server.ArtifactHubRepoID,
+	}
+	log(cm_logger.DebugLevel, "Generating artifacthub-repo.yml file", "repo", repo)
+	rawArtifactHubFile, err := yaml.Marshal(&artifactHubFile)
+	if err != nil {
+		errStr := "failed to generate artifacthub-repo.yml file"
+		log(cm_logger.ErrorLevel, errStr,
+			"repo", repo,
+		)
+		return nil, &HTTPError{http.StatusInternalServerError, errStr}
+	}
+	return rawArtifactHubFile, nil
+}

--- a/pkg/chartmuseum/server/multitenant/artifacthub.go
+++ b/pkg/chartmuseum/server/multitenant/artifacthub.go
@@ -17,8 +17,9 @@ limitations under the License.
 package multitenant
 
 import (
-	"github.com/ghodss/yaml"
 	"net/http"
+
+	"github.com/ghodss/yaml"
 
 	cm_logger "helm.sh/chartmuseum/pkg/chartmuseum/logger"
 	cm_repo "helm.sh/chartmuseum/pkg/repo"
@@ -27,8 +28,11 @@ import (
 const artifactHubFileContentType = "application/x-yaml"
 
 func (server *MultiTenantServer) getArtifactHubYml(log cm_logger.LoggingFn, repo string) ([]byte, *HTTPError) {
+	if _, ok := server.ArtifactHubRepoID[repo]; !ok {
+		return nil, &HTTPError{http.StatusNotFound, "Artifact Hub repository ID not found"}
+	}
 	artifactHubFile := &cm_repo.ArtifactHubFile{
-		RepoID: server.ArtifactHubRepoID,
+		RepoID: server.ArtifactHubRepoID[repo],
 	}
 	log(cm_logger.DebugLevel, "Generating artifacthub-repo.yml file", "repo", repo)
 	rawArtifactHubFile, err := yaml.Marshal(&artifactHubFile)

--- a/pkg/chartmuseum/server/multitenant/handlers.go
+++ b/pkg/chartmuseum/server/multitenant/handlers.go
@@ -129,6 +129,18 @@ func (server *MultiTenantServer) getIndexFileRequestHandler(c *gin.Context) {
 	c.Data(200, indexFileContentType, indexFile.Raw)
 }
 
+func (server *MultiTenantServer) getArtifactHubFileRequestHandler(c *gin.Context) {
+	repo := c.Param("repo")
+	log := server.Logger.ContextLoggingFn(c)
+	artifactHubFile, err := server.getArtifactHubYml(log, repo)
+	if err != nil {
+		c.JSON(err.Status, gin.H{"error": err.Message})
+		return
+	}
+
+	c.Data(200, artifactHubFileContentType, artifactHubFile)
+}
+
 func (server *MultiTenantServer) getStorageObjectRequestHandler(c *gin.Context) {
 	repo := c.Param("repo")
 	filename := c.Param("filename")

--- a/pkg/chartmuseum/server/multitenant/index.go
+++ b/pkg/chartmuseum/server/multitenant/index.go
@@ -25,7 +25,7 @@ import (
 	cm_repo "helm.sh/chartmuseum/pkg/repo"
 )
 
-var (
+const (
 	indexFileContentType = "application/x-yaml"
 )
 

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -30,6 +30,10 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 		{"GET", "/health", s.getHealthCheckHandler, ""},
 	}
 
+	artifactHubRoutes := []*cm_router.Route{
+		{"GET", "/artifacthub-repo.yml", s.getArtifactHubFileRequestHandler, cm_auth.PullAction},
+	}
+
 	helmChartRepositoryRoutes := []*cm_router.Route{
 		{"GET", "/:repo/index.yaml", s.getIndexFileRequestHandler, cm_auth.PullAction},
 		{"GET", "/:repo/charts/:filename", s.getStorageObjectRequestHandler, cm_auth.PullAction},
@@ -49,6 +53,10 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 
 	routes = append(routes, serverInfoRoutes...)
 	routes = append(routes, helmChartRepositoryRoutes...)
+
+	if s.ArtifactHubRepoID != "" {
+		routes = append(routes, artifactHubRoutes...)
+	}
 
 	if s.WebTemplatePath != "" {
 		routes = append(routes, &cm_router.Route{

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -18,6 +18,7 @@ package multitenant
 
 import (
 	cm_auth "github.com/chartmuseum/auth"
+
 	cm_router "helm.sh/chartmuseum/pkg/chartmuseum/router"
 )
 
@@ -54,7 +55,7 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 	routes = append(routes, serverInfoRoutes...)
 	routes = append(routes, helmChartRepositoryRoutes...)
 
-	if s.ArtifactHubRepoID != "" {
+	if s.ArtifactHubRepoID != nil {
 		routes = append(routes, artifactHubRoutes...)
 	}
 

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -55,7 +55,7 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 	routes = append(routes, serverInfoRoutes...)
 	routes = append(routes, helmChartRepositoryRoutes...)
 
-	if s.ArtifactHubRepoID != nil {
+	if len(s.ArtifactHubRepoID) != 0 {
 		routes = append(routes, artifactHubRoutes...)
 	}
 

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -67,6 +67,7 @@ type (
 		CacheInterval          time.Duration
 		EventChan              chan event
 		ChartLimits            *ObjectsPerChartLimit
+		ArtifactHubRepoID      string
 		// Deprecated: see https://github.com/helm/chartmuseum/issues/485 for more info
 		EnforceSemver2  bool
 		WebTemplatePath string
@@ -98,9 +99,10 @@ type (
 		UseStatefiles          bool
 		CacheInterval          time.Duration
 		PerChartLimit          int
+		ArtifactHubRepoID      string
+		WebTemplatePath        string
 		// Deprecated: see https://github.com/helm/chartmuseum/issues/485 for more info
-		EnforceSemver2  bool
-		WebTemplatePath string
+		EnforceSemver2 bool
 	}
 
 	tenantInternals struct {
@@ -159,6 +161,7 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 		CacheInterval:          options.CacheInterval,
 		ChartLimits:            l,
 		WebTemplatePath:        options.WebTemplatePath,
+		ArtifactHubRepoID:      options.ArtifactHubRepoID,
 	}
 
 	if server.WebTemplatePath != "" {

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -25,6 +25,7 @@ import (
 
 	cm_storage "github.com/chartmuseum/storage"
 	"github.com/gin-gonic/gin"
+
 	"helm.sh/chartmuseum/pkg/cache"
 	cm_logger "helm.sh/chartmuseum/pkg/chartmuseum/logger"
 	cm_router "helm.sh/chartmuseum/pkg/chartmuseum/router"
@@ -67,7 +68,7 @@ type (
 		CacheInterval          time.Duration
 		EventChan              chan event
 		ChartLimits            *ObjectsPerChartLimit
-		ArtifactHubRepoID      string
+		ArtifactHubRepoID      map[string]string
 		// Deprecated: see https://github.com/helm/chartmuseum/issues/485 for more info
 		EnforceSemver2  bool
 		WebTemplatePath string
@@ -99,7 +100,7 @@ type (
 		UseStatefiles          bool
 		CacheInterval          time.Duration
 		PerChartLimit          int
-		ArtifactHubRepoID      string
+		ArtifactHubRepoID      map[string]string
 		WebTemplatePath        string
 		// Deprecated: see https://github.com/helm/chartmuseum/issues/485 for more info
 		EnforceSemver2 bool

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/urfave/cli"
+
 	cm_logger "helm.sh/chartmuseum/pkg/chartmuseum/logger"
 )
 
@@ -75,6 +76,12 @@ func (conf *Config) UpdateFromCLIContext(c *cli.Context) error {
 					conf.Set(key, c.Bool(name))
 				case durationType:
 					conf.Set(key, c.Duration(name))
+				case keyValueType:
+					keyValue, ok := c.Generic(name).(*KeyValueFlag)
+					if !ok {
+						return fmt.Errorf("failed to get flag value: %s", flag.GetName())
+					}
+					conf.Set(key, keyValue.m)
 				}
 			}
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -129,6 +129,15 @@ func (suite *ConfigTestSuite) TestUpdateFromCLIContext() {
 	suite.Nil(err)
 	suite.Equal("otherdude", conf.GetString("basicauth.user"))
 	suite.Equal("mypass", conf.GetString("basicauth.pass"))
+
+	// Tests KeyValueFlag "generic" flag implementation
+	conf = NewConfig()
+	suite.NotNil(conf)
+	c = getNewContext()
+	c.Set("artifact-hub-repo-id", "foo=bar")
+	err = conf.UpdateFromCLIContext(c)
+	suite.Nil(err)
+	suite.Equal(map[string]string{"foo": "bar"}, conf.GetStringMapString("artifact-hub-repo-id"))
 }
 
 func getNewContext() *cli.Context {

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/urfave/cli"
@@ -41,6 +43,7 @@ var (
 	intType      configVarType = "int"
 	boolType     configVarType = "bool"
 	durationType configVarType = "time.Duration"
+	keyValueType configVarType = "keyValue"
 )
 
 var configVars = map[string]configVar{
@@ -806,14 +809,40 @@ var configVars = map[string]configVar{
 		},
 	},
 	"artifact-hub-repo-id": {
-		Type:    stringType,
-		Default: "",
-		CLIFlag: cli.StringFlag{
-			Name:   "artifact-hub-repo-id",
-			Usage:  "the artifact hub repositoryID used to populate a artifacthub-repo.yml file (only supports a single repo ID that is applied to all ChartMuseum repos)",
+		Type: keyValueType,
+		CLIFlag: cli.GenericFlag{
+			Name:  "artifact-hub-repo-id",
+			Value: &KeyValueFlag{},
+			Usage: "the artifact hub repositoryID used to populate a artifacthub-repo.yml file. " +
+				"This can be a single repository ID for depth=0 servers or a key value pair for depth=N servers (i.e org1/repo1=foo).",
 			EnvVar: "ARTIFACT_HUB_REPO_ID",
 		},
 	},
+}
+
+type KeyValueFlag struct {
+	m map[string]string
+}
+
+func (k *KeyValueFlag) Set(value string) error {
+	if k.m == nil {
+		k.m = make(map[string]string)
+	}
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) == 1 { // depth=0 case
+		k.m[""] = parts[0]
+	} else if len(parts) == 2 {
+		k.m[parts[0]] = parts[1]
+	}
+	return nil
+}
+
+func (k *KeyValueFlag) String() string {
+	var str []string
+	for key, val := range k.m {
+		str = append(str, fmt.Sprintf("%s=%s", key, val))
+	}
+	return strings.Join(str, ",")
 }
 
 func populateCLIFlags() {

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -805,6 +805,15 @@ var configVars = map[string]configVar{
 			EnvVar: "WEB_TEMPLATE_PATH",
 		},
 	},
+	"artifact-hub-repo-id": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "artifact-hub-repo-id",
+			Usage:  "the artifact hub repositoryID used to populate a artifacthub-repo.yml file (only supports a single repo ID that is applied to all ChartMuseum repos)",
+			EnvVar: "ARTIFACT_HUB_REPO_ID",
+		},
+	},
 }
 
 func populateCLIFlags() {

--- a/pkg/repo/artifacthub.go
+++ b/pkg/repo/artifacthub.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repo
+
+type ArtifactHubFile struct {
+	RepoID string `json:"repositoryID"`
+}


### PR DESCRIPTION
Fixes https://github.com/helm/chartmuseum/issues/419.

This is an initial take at hosting an `artifacthub-repo.yml` from ChartMuseum.

Currently, it will only support setting the `repositoryID` in the `artifacthub-repo.yml` file, but adding more fields in the future shouldn't be too difficult.

Let me know what you think, especially the CLI flag implementation for multitenancy.

