### PR TITLE
pkg/chartmuseum,cmd: introduce the new `keep-chart-always-up-to-date` flag and the default cache interval when not set.

### DIFF
--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -118,6 +118,7 @@ func cliHandler(c *cli.Context) {
 		PerChartLimit:          conf.GetInt("per-chart-limit"),
 		WebTemplatePath:        conf.GetString("web-template-path"),
 		ArtifactHubRepoID:      conf.GetStringMapString("artifact-hub-repo-id"),
+		AlwaysRegenerateIndex:  conf.GetBool("always-regenerate-index"),
 	}
 
 	server, err := newServer(options)

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -118,7 +118,7 @@ func cliHandler(c *cli.Context) {
 		PerChartLimit:          conf.GetInt("per-chart-limit"),
 		WebTemplatePath:        conf.GetString("web-template-path"),
 		ArtifactHubRepoID:      conf.GetStringMapString("artifact-hub-repo-id"),
-		AlwaysRegenerateIndex:  conf.GetBool("always-regenerate-index"),
+		AlwaysRegenerateIndex:  conf.GetBool("always-regenerate-chart-index"),
 	}
 
 	server, err := newServer(options)

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -81,6 +81,9 @@ type (
 		Debug bool
 		// Deprecated: LogJSON is no longer effective. ServerOptions now requires the Logger field to be set and configured with LoggerOptions accordingly.
 		LogJSON bool
+		// AlwaysRegenerateIndex represents if the museum always return the up-to-date chart
+		// which means that the GetChart will increase its latency , be careful to enable this .
+		AlwaysRegenerateIndex bool
 	}
 
 	// Server is a generic interface for web servers
@@ -146,7 +149,8 @@ func NewServer(options ServerOptions) (Server, error) {
 		WebTemplatePath:        options.WebTemplatePath,
 		// Deprecated options
 		// EnforceSemver2 - see https://github.com/helm/chartmuseum/issues/485 for more info
-		EnforceSemver2: options.EnforceSemver2,
+		EnforceSemver2:        options.EnforceSemver2,
+		AlwaysRegenerateIndex: options.AlwaysRegenerateIndex,
 	})
 
 	return server, err

--- a/pkg/chartmuseum/server/multitenant/cache.go
+++ b/pkg/chartmuseum/server/multitenant/cache.go
@@ -598,9 +598,7 @@ func (server *MultiTenantServer) refreshCacheEntry(log cm_logger.LoggingFn, repo
 		)
 		return
 	}
-	entry.RepoLock.Lock()
-	defer entry.RepoLock.Unlock()
-	objects := server.getRepoObjectSlice(entry)
+	objects := server.getRepoObjectSliceWithLock(entry)
 	diff := cm_storage.GetObjectSliceDiff(objects, fo.objects, server.TimestampTolerance)
 
 	// return fast if no changes
@@ -614,6 +612,9 @@ func (server *MultiTenantServer) refreshCacheEntry(log cm_logger.LoggingFn, repo
 	log(cm_logger.DebugLevel, "Change detected between cache and storage",
 		"repo", repo,
 	)
+
+	entry.RepoLock.Lock()
+	defer entry.RepoLock.Unlock()
 
 	ir := <-server.regenerateRepositoryIndex(log, entry, diff)
 	if ir.err != nil {

--- a/pkg/chartmuseum/server/multitenant/cache.go
+++ b/pkg/chartmuseum/server/multitenant/cache.go
@@ -477,10 +477,11 @@ func (server *MultiTenantServer) initCacheTimer() {
 		// (in case the files on the disk are manually manipulated)
 		go func() {
 			t := time.NewTicker(server.CacheInterval)
-			for _ = range t.C {
+			for range t.C {
 				server.rebuildIndex()
 			}
 		}()
+
 	}
 }
 
@@ -496,7 +497,6 @@ func (server *MultiTenantServer) emitEvent(c *gin.Context, repo string, operatio
 func (server *MultiTenantServer) startEventListener() {
 	server.Router.Logger.Debug("Starting internal event listener")
 	for {
-
 		e := <-server.EventChan
 		log := server.Logger.ContextLoggingFn(e.Context)
 

--- a/pkg/chartmuseum/server/multitenant/cache.go
+++ b/pkg/chartmuseum/server/multitenant/cache.go
@@ -565,11 +565,13 @@ func (server *MultiTenantServer) startEventListener() {
 }
 
 func (server *MultiTenantServer) rebuildIndex() {
+	server.TenantCacheKeyLock.Lock()
+	defer server.TenantCacheKeyLock.Unlock()
 	if len(server.Tenants) == 0 {
 		return
 	}
 	server.Logger.Info("Rebuilding index for all tenants in cache")
-	for repo, _ := range server.Tenants {
+	for repo := range server.Tenants {
 		go server.rebuildIndexForTenant(repo)
 	}
 }

--- a/pkg/chartmuseum/server/multitenant/handlers.go
+++ b/pkg/chartmuseum/server/multitenant/handlers.go
@@ -311,7 +311,7 @@ func (server *MultiTenantServer) deleteChartVersionRequestHandler(c *gin.Context
 		return
 	}
 
-	server.emitEvent(c, repo, deleteChart, &helm_repo.ChartVersion{
+	 server.emitEvent(c, repo, deleteChart, &helm_repo.ChartVersion{
 		Metadata: &chart.Metadata{
 			Name:    name,
 			Version: version,

--- a/pkg/chartmuseum/server/multitenant/handlers_test.go
+++ b/pkg/chartmuseum/server/multitenant/handlers_test.go
@@ -43,7 +43,9 @@ func (suite *HandlerTestSuite) getServer(depth int) *MultiTenantServer {
 		ChartPostFormFieldName: "chart",
 		ProvPostFormFieldName:  "prov",
 		IndexLimit:             1,
+		CacheInterval:          time.Second,
 	})
+	suite.NoError(err, "no error creating server")
 	return serverDepth
 }
 

--- a/pkg/chartmuseum/server/multitenant/index.go
+++ b/pkg/chartmuseum/server/multitenant/index.go
@@ -41,7 +41,7 @@ func (server *MultiTenantServer) getIndexFile(log cm_logger.LoggingFn, repo stri
 	entry.RepoLock.Lock()
 	defer entry.RepoLock.Unlock()
 
-	// if the always-regenerate-index flag is set, we always update the index file
+	// if the always-regenerate-chart-index flag is set, we always update the index file
 	// and ignore the chart cache
 	if server.AlwaysRegenerateIndex /* the flag is set */ ||
 		(!server.AlwaysRegenerateIndex && len(entry.RepoIndex.Entries) == 0) /* initial */ {

--- a/pkg/chartmuseum/server/multitenant/index.go
+++ b/pkg/chartmuseum/server/multitenant/index.go
@@ -40,9 +40,12 @@ func (server *MultiTenantServer) getIndexFile(log cm_logger.LoggingFn, repo stri
 	}
 
 	entry.RepoLock.Lock()
+
 	defer entry.RepoLock.Unlock()
-	// if cache is nil, and not on a timer, regenerate it
-	if len(entry.RepoIndex.Entries) == 0 && server.CacheInterval == 0 {
+	// if the always-regenerate-index flag is set, we always update the index file
+	// and ignore the chart cache
+	if server.AlwaysRegenerateIndex /* the flag is set */ ||
+		(!server.AlwaysRegenerateIndex && len(entry.RepoIndex.Entries) == 0) /* initial */ {
 
 		fo := <-server.getChartList(log, repo)
 

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -70,8 +70,9 @@ type (
 		ChartLimits            *ObjectsPerChartLimit
 		ArtifactHubRepoID      map[string]string
 		// Deprecated: see https://github.com/helm/chartmuseum/issues/485 for more info
-		EnforceSemver2  bool
-		WebTemplatePath string
+		EnforceSemver2        bool
+		WebTemplatePath       string
+		AlwaysRegenerateIndex bool
 	}
 
 	ObjectsPerChartLimit struct {
@@ -103,7 +104,8 @@ type (
 		ArtifactHubRepoID      map[string]string
 		WebTemplatePath        string
 		// Deprecated: see https://github.com/helm/chartmuseum/issues/485 for more info
-		EnforceSemver2 bool
+		EnforceSemver2        bool
+		AlwaysRegenerateIndex bool
 	}
 
 	tenantInternals struct {
@@ -163,6 +165,7 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 		ChartLimits:            l,
 		WebTemplatePath:        options.WebTemplatePath,
 		ArtifactHubRepoID:      options.ArtifactHubRepoID,
+		AlwaysRegenerateIndex:  options.AlwaysRegenerateIndex,
 	}
 
 	if server.WebTemplatePath != "" {

--- a/pkg/chartmuseum/server/multitenant/server_test.go
+++ b/pkg/chartmuseum/server/multitenant/server_test.go
@@ -541,8 +541,8 @@ func (suite *MultiTenantServerTestSuite) SetupSuite() {
 		AllowOverwrite:         true,
 		ChartPostFormFieldName: "chart",
 		ProvPostFormFieldName:  "prov",
-		AlwaysRegenerateIndex:  true,
 		CacheInterval:          time.Second,
+		AlwaysRegenerateIndex:  true,
 	})
 
 	suite.NotNil(server)
@@ -586,7 +586,7 @@ func (suite *MultiTenantServerTestSuite) regenerateRepositoryIndex(repo string, 
 		return
 	}
 	suite.Nil(err, "no error on fetchChartsInStorage")
-	diff := storage.GetObjectSliceDiff(server.getRepoObjectSlice(entry), objects, server.TimestampTolerance)
+	diff := storage.GetObjectSliceDiff(server.getRepoObjectSliceWithLock(entry), objects, server.TimestampTolerance)
 	_, err = server.regenerateRepositoryIndexWorker(log, entry, diff)
 	suite.Nil(err, "no error regenerating repo index")
 
@@ -596,7 +596,7 @@ func (suite *MultiTenantServerTestSuite) regenerateRepositoryIndex(repo string, 
 
 	objects, err = server.fetchChartsInStorage(log, repo)
 	suite.Nil(err, "no error on fetchChartsInStorage")
-	diff = storage.GetObjectSliceDiff(server.getRepoObjectSlice(entry), objects, server.TimestampTolerance)
+	diff = storage.GetObjectSliceDiff(server.getRepoObjectSliceWithLock(entry), objects, server.TimestampTolerance)
 	_, err = server.regenerateRepositoryIndexWorker(log, entry, diff)
 	suite.Nil(err, "no error regenerating repo index with tarball updated")
 
@@ -606,7 +606,7 @@ func (suite *MultiTenantServerTestSuite) regenerateRepositoryIndex(repo string, 
 	defer destFile.Close()
 	objects, err = server.fetchChartsInStorage(log, repo)
 	suite.Nil(err, "no error on fetchChartsInStorage")
-	diff = storage.GetObjectSliceDiff(server.getRepoObjectSlice(entry), objects, server.TimestampTolerance)
+	diff = storage.GetObjectSliceDiff(server.getRepoObjectSliceWithLock(entry), objects, server.TimestampTolerance)
 	_, err = server.regenerateRepositoryIndexWorker(log, entry, diff)
 	suite.Nil(err, "error not returned with broken tarball added")
 
@@ -614,7 +614,7 @@ func (suite *MultiTenantServerTestSuite) regenerateRepositoryIndex(repo string, 
 	suite.Nil(err, "no error changing modtime on broken tarball")
 	objects, err = server.fetchChartsInStorage(log, repo)
 	suite.Nil(err, "no error on fetchChartsInStorage")
-	diff = storage.GetObjectSliceDiff(server.getRepoObjectSlice(entry), objects, server.TimestampTolerance)
+	diff = storage.GetObjectSliceDiff(server.getRepoObjectSliceWithLock(entry), objects, server.TimestampTolerance)
 	_, err = server.regenerateRepositoryIndexWorker(log, entry, diff)
 	suite.Nil(err, "error not returned with broken tarball updated")
 
@@ -622,7 +622,7 @@ func (suite *MultiTenantServerTestSuite) regenerateRepositoryIndex(repo string, 
 	suite.Nil(err, "no error removing broken tarball")
 	objects, err = server.fetchChartsInStorage(log, repo)
 	suite.Nil(err, "no error on fetchChartsInStorage")
-	diff = storage.GetObjectSliceDiff(server.getRepoObjectSlice(entry), objects, server.TimestampTolerance)
+	diff = storage.GetObjectSliceDiff(server.getRepoObjectSliceWithLock(entry), objects, server.TimestampTolerance)
 	_, err = server.regenerateRepositoryIndexWorker(log, entry, diff)
 	suite.Nil(err, "error not returned with broken tarball removed")
 }

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -54,6 +54,7 @@ func (suite *ServerTestSuite) TestNewServer() {
 	serverOptions := ServerOptions{
 		StorageBackend: suite.Backend,
 		Logger:         log,
+		CacheInterval:  time.Second ,
 	}
 
 	multiTenantServer, err := NewServer(serverOptions)

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -52,9 +52,9 @@ func (suite *ServerTestSuite) TestNewServer() {
 	})
 	suite.Nil(err, "no error creating logger")
 	serverOptions := ServerOptions{
-		StorageBackend: suite.Backend,
-		Logger:         log,
-		CacheInterval:  time.Second ,
+		StorageBackend:        suite.Backend,
+		Logger:                log,
+		AlwaysRegenerateIndex: true,
 	}
 
 	multiTenantServer, err := NewServer(serverOptions)

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -822,7 +822,7 @@ var configVars = map[string]configVar{
 		Type: boolType,
 		CLIFlag: cli.BoolFlag{
 			Name:   "always-regenerate-chart-index",
-			Usage:  "always regenerate the chart index and ignore the chart cache , it will cost the even more disk I/O",
+			Usage:  "always regenerate the chart index and ignore the chart cache (this will result in decreased performance and an increase in resource consumption)",
 			EnvVar: "ALWAYS_REGENERATE_CHART_INDEX",
 		},
 	},

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -774,7 +774,7 @@ var configVars = map[string]configVar{
 	},
 	"cacheinterval": {
 		Type:    durationType,
-		Default: time.Duration(0),
+		Default: 5 * time.Minute,
 		CLIFlag: cli.DurationFlag{
 			Name:   "cache-interval",
 			Usage:  "set the interval of delta updating the cache",
@@ -816,6 +816,14 @@ var configVars = map[string]configVar{
 			Usage: "the artifact hub repositoryID used to populate a artifacthub-repo.yml file. " +
 				"This can be a single repository ID for depth=0 servers or a key value pair for depth=N servers (i.e org1/repo1=foo).",
 			EnvVar: "ARTIFACT_HUB_REPO_ID",
+		},
+	},
+	"always-regenerate-chart-index": {
+		Type: boolType,
+		CLIFlag: cli.BoolFlag{
+			Name:   "always-regenerate-chart-index",
+			Usage:  "always regenerate the chart index and ignore the chart cache , it will cost the even more disk I/O",
+			EnvVar: "ALWAYS_REGENERATE_CHART_INDEX",
 		},
 	},
 }


### PR DESCRIPTION
Closes #444

* The flags works to always get the realtime index for the chart repository(which is the behavior before v0.13.0), it will cost more fs I/O.
* Default interval is now set to 5m when `cache-interval` flag not set which we suggests in the issue list.

Signed-off-by: scnace <scbizu@gmail.com>