### PR TITLE
feat: Remove NetEase object storage provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><img align="center" src="logo2.png"></p><br/>
 
-*ChartMuseum* is an open-source **[Helm Chart Repository](https://helm.sh/docs/topics/chart_repository/)** server written in Go (Golang), with support for cloud storage backends, including [Google Cloud Storage](https://cloud.google.com/storage/), [Amazon S3](https://aws.amazon.com/s3/), [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/), [Alibaba Cloud OSS Storage](https://www.alibabacloud.com/product/oss), [Openstack Object Storage](https://developer.openstack.org/api-ref/object-store/), [Oracle Cloud Infrastructure Object Storage](https://cloud.oracle.com/storage), [Baidu Cloud BOS Storage](https://cloud.baidu.com/product/bos.html), [Tencent Cloud Object Storage](https://intl.cloud.tencent.com/product/cos), [Netease Cloud NOS Storage](https://www.163yun.com/product/nos), [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces/), [Minio](https://min.io/), and [etcd](https://etcd.io/).
+*ChartMuseum* is an open-source **[Helm Chart Repository](https://helm.sh/docs/topics/chart_repository/)** server written in Go (Golang), with support for cloud storage backends, including [Google Cloud Storage](https://cloud.google.com/storage/), [Amazon S3](https://aws.amazon.com/s3/), [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/), [Alibaba Cloud OSS Storage](https://www.alibabacloud.com/product/oss), [Openstack Object Storage](https://developer.openstack.org/api-ref/object-store/), [Oracle Cloud Infrastructure Object Storage](https://cloud.oracle.com/storage), [Baidu Cloud BOS Storage](https://cloud.baidu.com/product/bos.html), [Tencent Cloud Object Storage](https://intl.cloud.tencent.com/product/cos), [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces/), [Minio](https://min.io/), and [etcd](https://etcd.io/).
 
 Works as a valid Helm Chart Repository, and also provides an API for uploading charts.
 
@@ -340,22 +340,6 @@ chartmuseum --debug --port=8080 \
   --storage-tencent-bucket="my-cos-bucket" \
   --storage-tencent-prefix="" \
   --storage-tencent-endpoint="cos.ap-beijing.myqcloud.com"
-```
-
-#### Using with Netease Cloud NOS Storage
-
-Make sure your environment is properly setup to access `my-nos-bucket`.
-
-To do so, you must set the following env vars:
-- `NETEASE_CLOUD_ACCESS_KEY_ID`
-- `NETEASE_CLOUD_ACCESS_KEY_SECRET`
-
-```bash
-chartmuseum --debug --port=8080 \
-  --storage="netease" \
-  --storage-netease-bucket="my-nos-bucket" \
-  --storage-netease-prefix="" \
-  --storage-netease-endpoint="nos-eastchina1.126.net"
 ```
 
 #### Using with etcd

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -156,8 +156,6 @@ func backendFromConfig(conf *config.Config) storage.Backend {
 		backend = etcdBackendFromConfig(conf)
 	case "tencent":
 		backend = tencentBackendFromConfig(conf)
-	case "netease":
-		backend = neteaseBackendFromConfig(conf)
 	default:
 		crash("Unsupported storage backend: ", storageFlag)
 	}
@@ -276,15 +274,6 @@ func tencentBackendFromConfig(conf *config.Config) storage.Backend {
 		conf.GetString("storage.tencent.bucket"),
 		conf.GetString("storage.tencent.prefix"),
 		conf.GetString("storage.tencent.endpoint"),
-	)
-}
-
-func neteaseBackendFromConfig(conf *config.Config) storage.Backend {
-	crashIfConfigMissingVars(conf, []string{"storage.netease.bucket"})
-	return storage.NewNeteaseNOSBackend(
-		conf.GetString("storage.netease.bucket"),
-		conf.GetString("storage.netease.prefix"),
-		conf.GetString("storage.netease.endpoint"),
 	)
 }
 

--- a/cmd/chartmuseum/main_test.go
+++ b/cmd/chartmuseum/main_test.go
@@ -101,10 +101,6 @@ func (suite *MainTestSuite) TestMain() {
 	suite.Panics(main, "baidu storage")
 	suite.Equal("graceful crash", suite.LastCrashMessage, "no error with baidu backend")
 
-	os.Args = []string{"chartmuseum", "--storage", "netease", "--storage-netease-bucket", "x", "--storage-netease-endpoint", "nos-eastchina1.126.net"}
-	suite.Panics(main, "netease storage")
-	suite.Equal("graceful crash", suite.LastCrashMessage, "no error with netease backend")
-
 	// Redis cache
 	os.Args = []string{"chartmuseum", "--storage", "local", "--storage-local-rootdir", "../../.chartstorage", "--cache", "redis", "--cache-redis-addr", suite.RedisMock.Addr()}
 	suite.Panics(main, "redis cache")

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/chartmuseum/auth v0.5.0
-	github.com/chartmuseum/storage v0.12.5
+	github.com/chartmuseum/storage v0.13.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-contrib/size v0.0.0-20220102055520-f75bacbc2df3
 	github.com/gin-gonic/gin v1.8.1
@@ -36,7 +36,6 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
-	github.com/NetEase-Object-Storage/nos-golang-sdk v0.0.0-20191125093154-335c2b73bf6b // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,6 @@ github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030I
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
 github.com/Microsoft/hcsshim v0.9.3 h1:k371PzBuRrz2b+ebGuI2nVgVhgsVX60jMfSw80NECxo=
-github.com/NetEase-Object-Storage/nos-golang-sdk v0.0.0-20191125093154-335c2b73bf6b h1:jZIv0SILYL0wRLzAB8Ha19VDm7JnYn8t9NYbz2s2AVc=
-github.com/NetEase-Object-Storage/nos-golang-sdk v0.0.0-20191125093154-335c2b73bf6b/go.mod h1:0N5CbwYI/8V1T6YOEwkgMvLmiGDNn661vLutBZQrC2c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -136,8 +134,8 @@ github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cb
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chartmuseum/auth v0.5.0 h1:ENNmoxvjxcR/JR0HrghAEtGQe7hToMNj16+UoS5CK9Y=
 github.com/chartmuseum/auth v0.5.0/go.mod h1:BvoSXHyvbsq+/bbhNgVTDQsModM+HERBTNY5o9Vyrig=
-github.com/chartmuseum/storage v0.12.5 h1:mPZOG2wVHgCe3CjdPnVGMMX/8LSbwC5TQiOTyFI1Aj4=
-github.com/chartmuseum/storage v0.12.5/go.mod h1:hs0Gu9+cTt9gY2BOrTnyvJ2xWwGInPDIwfzQJhhy7hg=
+github.com/chartmuseum/storage v0.13.0 h1:1HjwJwZiisUrF8ZTSmGoIXorctBmvA8J5PIGu7kR+60=
+github.com/chartmuseum/storage v0.13.0/go.mod h1:4g1fp4OlfGeVZcgQH+7XKp9a0MiVKPZyP3JJQIre1a0=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -607,34 +607,6 @@ var configVars = map[string]configVar{
 			EnvVar: "STORAGE_TENCENT_ENDPOINT",
 		},
 	},
-	"storage.netease.prefix": {
-		Type:    stringType,
-		Default: "",
-		CLIFlag: cli.StringFlag{
-			Name:   "storage-netease-prefix",
-			Usage:  "prefix to store charts for --storage-netease-cloud-bucket",
-			EnvVar: "STORAGE_NETEASE_PREFIX",
-		},
-	},
-	"storage.netease.bucket": {
-		Type:    stringType,
-		Default: "",
-		CLIFlag: cli.StringFlag{
-			Name:   "storage-netease-bucket",
-			Usage:  "NOS bucket to store charts for Netease Cloud storage backend",
-			EnvVar: "STORAGE_NETEASE_BUCKET",
-		},
-	},
-	"storage.netease.endpoint": {
-		Type:    stringType,
-		Default: "",
-		CLIFlag: cli.StringFlag{
-			Name:   "storage-netease-endpoint",
-			Usage:  "NOS endpoint",
-			EnvVar: "STORAGE_NETEASE_ENDPOINT",
-		},
-	},
-
 	"chartpostformfieldname": {
 		Type:    stringType,
 		Default: "chart",


### PR DESCRIPTION
Drops support for the NetEase object storage provider per https://github.com/helm/chartmuseum/issues/646