### PR TITLE
ci: pin buildx version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,9 @@ jobs:
           platforms: all
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
-          version: latest
+          version: v0.9.1
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Docker Login


### PR DESCRIPTION
The `build` action on [main](https://github.com/helm/chartmuseum/actions/runs/3896409100/jobs/7137221860) is failing because of some issue with one of the images built via buildx (which causes the sbom generation to fail)

```
level=fatal msg="generating doc: creating SPDX document: generating SPDX package from image ref ghcr.io/helm/chartmuseum:canary: adding image variant package: getting os data from container: reading os type from layer: reading os release: extracting os-release from tar: reading tarfile: archive/tar: invalid tar header"
```

I looked and I noticed the last successful run [here](https://github.com/helm/chartmuseum/actions/runs/3705572068/jobs/6279651718) is using `v0.9.1` and the recent failures are using buildx version `v0.10.2`. So for now, lets pin to the known working version and I'll create an issue to look into bumping it. 

