### PR TITLE
fix: update URLs in k8s mirror script

### DIFF
--- a/scripts/mirror-k8s-repos.sh
+++ b/scripts/mirror-k8s-repos.sh
@@ -22,7 +22,7 @@ get_all_tgzs() {
 }
 
 # Stable
-get_all_tgzs https://kubernetes-charts.storage.googleapis.com
+get_all_tgzs https://charts.helm.sh/stable
 
 # Incubator
-get_all_tgzs https://kubernetes-charts-incubator.storage.googleapis.com
+get_all_tgzs https://charts.helm.sh/incubator


### PR DESCRIPTION
Pointing URLs in script to the new ones ref. https://helm.sh/blog/new-location-stable-incubator-charts/