### PR TITLE
replace io/ioutil package with os package

### DIFF
--- a/pkg/chartmuseum/router/router.go
+++ b/pkg/chartmuseum/router/router.go
@@ -20,8 +20,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"time"
 
@@ -186,7 +186,7 @@ func (router *Router) Start(port int) {
 		if router.TlsCACert != "" {
 			keypair, _ := tls.LoadX509KeyPair(router.TlsCert, router.TlsKey)
 			certpool := x509.NewCertPool()
-			capem, _ := ioutil.ReadFile(router.TlsCACert)
+			capem, _ := os.ReadFile(router.TlsCACert)
 			if !certpool.AppendCertsFromPEM(capem) {
 				router.Logger.Fatal("Can't parse CA certificate file")
 			}

--- a/pkg/chartmuseum/server/multitenant/server_test.go
+++ b/pkg/chartmuseum/server/multitenant/server_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -677,7 +676,7 @@ entries:
     - charts/acs-engine-autoscaler-2.1.2.tgz
     version: 2.1.2
 generated: "2018-05-23T15:14:46-05:00"`)
-	err = ioutil.WriteFile(indexCacheFilePath, content, 0644)
+	err = os.WriteFile(indexCacheFilePath, content, 0644)
 	suite.Nil(err, "no error creating test index-cache.yaml")
 	defer os.Remove(indexCacheFilePath)
 
@@ -700,7 +699,7 @@ generated: "2018-05-23T15:14:46-05:00"`)
 	// invalid, unparsable index-cache.yaml
 	indexCacheFilePath = pathutil.Join(suite.TempDirectory, repo.StatefileFilename)
 	content = []byte(`is this valid yaml? maybe. but its definitely not a valid index.yaml!`)
-	err = ioutil.WriteFile(indexCacheFilePath, content, 0644)
+	err = os.WriteFile(indexCacheFilePath, content, 0644)
 	suite.Nil(err, "no error creating test index-cache.yaml")
 
 	NewMultiTenantServer(MultiTenantServerOptions{
@@ -771,7 +770,7 @@ func (suite *MultiTenantServerTestSuite) extractRepoEntryFromInternalCache(repo 
 
 func (suite *MultiTenantServerTestSuite) TestOverwriteServer() {
 	// Check if files can be overwritten
-	content, err := ioutil.ReadFile(testTarballPath)
+	content, err := os.ReadFile(testTarballPath)
 	suite.Nil(err, "no error opening test tarball")
 	body := bytes.NewBuffer(content)
 	res := suite.doRequest("overwrite", "POST", "/api/charts", body, "")
@@ -792,7 +791,7 @@ func (suite *MultiTenantServerTestSuite) TestOverwriteServer() {
 		e.RepoLock.RUnlock()
 	}
 
-	content, err = ioutil.ReadFile(testProvfilePath)
+	content, err = os.ReadFile(testProvfilePath)
 	suite.Nil(err, "no error opening test provenance file")
 	body = bytes.NewBuffer(content)
 	res = suite.doRequest("overwrite", "POST", "/api/prov", body, "")
@@ -819,14 +818,14 @@ func (suite *MultiTenantServerTestSuite) TestOverwriteServer() {
 }
 
 func (suite *MultiTenantServerTestSuite) TestBadChartUpload() {
-	content, err := ioutil.ReadFile(badTestTarballPath)
+	content, err := os.ReadFile(badTestTarballPath)
 	suite.Nil(err, "no error opening test tarball")
 
 	body := bytes.NewBuffer(content)
 	res := suite.doRequest("depth0", "POST", "/api/charts", body, "")
 	suite.Equal(400, res.Status(), "400 POST /api/charts")
 
-	content, err = ioutil.ReadFile(badTestProvfilePath)
+	content, err = os.ReadFile(badTestProvfilePath)
 	suite.Nil(err, "no error opening test provenance file")
 
 	body = bytes.NewBuffer(content)
@@ -844,7 +843,7 @@ func (suite *MultiTenantServerTestSuite) TestForceOverwriteServer() {
 	suite.Equal(200, res.Status(), "200 DELETE /api/charts/mychart/0.1.0")
 
 	// Check if files can be overwritten when ?force is on URL
-	content, err := ioutil.ReadFile(testTarballPath)
+	content, err := os.ReadFile(testTarballPath)
 	suite.Nil(err, "no error opening test tarball")
 	body := bytes.NewBuffer(content)
 	res = suite.doRequest("forceoverwrite", "POST", "/api/charts", body, "")
@@ -856,7 +855,7 @@ func (suite *MultiTenantServerTestSuite) TestForceOverwriteServer() {
 	res = suite.doRequest("forceoverwrite", "POST", "/api/charts?force", body, "")
 	suite.Equal(201, res.Status(), "201 POST /api/charts?force")
 
-	content, err = ioutil.ReadFile(testProvfilePath)
+	content, err = os.ReadFile(testProvfilePath)
 	suite.Nil(err, "no error opening test provenance file")
 	body = bytes.NewBuffer(content)
 	res = suite.doRequest("forceoverwrite", "POST", "/api/prov", body, "")
@@ -890,26 +889,26 @@ func (suite *MultiTenantServerTestSuite) TestCustomChartURLServer() {
 
 func (suite *MultiTenantServerTestSuite) TestMaxObjectsServer() {
 	// Overwrites should still be allowed if limit is reached
-	content, err := ioutil.ReadFile(testTarballPath)
+	content, err := os.ReadFile(testTarballPath)
 	suite.Nil(err, "no error opening test tarball")
 	body := bytes.NewBuffer(content)
 	res := suite.doRequest("maxobjects", "POST", "/api/charts", body, "")
 	suite.Equal(201, res.Status(), "201 POST /api/charts")
 
-	content, err = ioutil.ReadFile(testProvfilePath)
+	content, err = os.ReadFile(testProvfilePath)
 	suite.Nil(err, "no error opening test provenance file")
 	body = bytes.NewBuffer(content)
 	res = suite.doRequest("maxobjects", "POST", "/api/prov", body, "")
 	suite.Equal(201, res.Status(), "201 POST /api/prov")
 
 	// trigger error, reached max
-	content, err = ioutil.ReadFile(otherTestTarballPath)
+	content, err = os.ReadFile(otherTestTarballPath)
 	suite.Nil(err, "no error opening other test tarball")
 	body = bytes.NewBuffer(content)
 	res = suite.doRequest("maxobjects", "POST", "/api/charts", body, "")
 	suite.Equal(507, res.Status(), "507 POST /api/charts")
 
-	content, err = ioutil.ReadFile(otherTestProvfilePath)
+	content, err = os.ReadFile(otherTestProvfilePath)
 	suite.Nil(err, "no error opening other test provenance file")
 	body = bytes.NewBuffer(content)
 	res = suite.doRequest("maxobjects", "POST", "/api/prov", body, "")
@@ -918,19 +917,19 @@ func (suite *MultiTenantServerTestSuite) TestMaxObjectsServer() {
 
 func (suite *MultiTenantServerTestSuite) TestPerChartLimit() {
 	ns := "per-chart-limit"
-	content, err := ioutil.ReadFile(testTarballPathV0)
+	content, err := os.ReadFile(testTarballPathV0)
 	suite.Nil(err, "no error opening test tarball")
 	body := bytes.NewBuffer(content)
 	res := suite.doRequest(ns, "POST", "/api/charts", body, "")
 	suite.Equal(201, res.Status(), "201 POST /api/charts")
 
-	content, err = ioutil.ReadFile(testTarballPathV2)
+	content, err = os.ReadFile(testTarballPathV2)
 	suite.Nil(err, "no error opening test tarball")
 	body = bytes.NewBuffer(content)
 	res = suite.doRequest(ns, "POST", "/api/charts", body, "")
 	suite.Equal(201, res.Status(), "201 POST /api/charts")
 
-	content, err = ioutil.ReadFile(testTarballPath)
+	content, err = os.ReadFile(testTarballPath)
 	suite.Nil(err, "no error opening test tarball")
 	body = bytes.NewBuffer(content)
 	res = suite.doRequest(ns, "POST", "/api/charts", body, "")
@@ -950,13 +949,13 @@ func (suite *MultiTenantServerTestSuite) TestPerChartLimit() {
 
 func (suite *MultiTenantServerTestSuite) TestMaxUploadSizeServer() {
 	// trigger 413s, "request too large"
-	content, err := ioutil.ReadFile(testTarballPath)
+	content, err := os.ReadFile(testTarballPath)
 	suite.Nil(err, "no error opening test tarball")
 	body := bytes.NewBuffer(content)
 	res := suite.doRequest("maxuploadsize", "POST", "/api/charts", body, "")
 	suite.Equal(413, res.Status(), "413 POST /api/charts")
 
-	content, err = ioutil.ReadFile(testProvfilePath)
+	content, err = os.ReadFile(testProvfilePath)
 	suite.Nil(err, "no error opening test provenance file")
 	body = bytes.NewBuffer(content)
 	res = suite.doRequest("maxuploadsize", "POST", "/api/prov", body, "")
@@ -971,14 +970,14 @@ func (suite *MultiTenantServerTestSuite) TestMetrics() {
 
 	apiPrefix := pathutil.Join("/api", "a")
 
-	content, err := ioutil.ReadFile(testTarballPath)
+	content, err := os.ReadFile(testTarballPath)
 	suite.Nil(err, "error opening test tarball")
 
 	body := bytes.NewBuffer(content)
 	res := suite.doRequest("depth1", "POST", fmt.Sprintf("%s/charts", apiPrefix), body, "")
 	suite.Equal(201, res.Status(), fmt.Sprintf("201 post %s/charts", apiPrefix))
 
-	otherChart, err := ioutil.ReadFile(testTarballPathV2)
+	otherChart, err := os.ReadFile(testTarballPathV2)
 	suite.Nil(err, "error opening test tarball")
 
 	body = bytes.NewBuffer(otherChart)
@@ -1204,7 +1203,7 @@ func (suite *MultiTenantServerTestSuite) testAllRoutes(repo string, depth int) {
 	suite.Equal(500, res.Status(), fmt.Sprintf("500 POST %s/prov", apiPrefix))
 
 	// POST /api/:repo/charts
-	content, err := ioutil.ReadFile(testTarballPath)
+	content, err := os.ReadFile(testTarballPath)
 	suite.Nil(err, "no error opening test tarball")
 
 	body = bytes.NewBuffer(content)
@@ -1221,7 +1220,7 @@ func (suite *MultiTenantServerTestSuite) testAllRoutes(repo string, depth int) {
 	suite.Equal(409, res.Status(), fmt.Sprintf("409 POST %s/charts?force", apiPrefix))
 
 	// POST /api/:repo/prov
-	content, err = ioutil.ReadFile(testProvfilePath)
+	content, err = os.ReadFile(testProvfilePath)
 	suite.Nil(err, "no error opening test provenance file")
 
 	body = bytes.NewBuffer(content)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	pathutil "path"
 	"testing"
@@ -50,7 +49,7 @@ basicauth:
 `,
 	)
 
-	err := ioutil.WriteFile(tempConfigFile, data, 0644)
+	err := os.WriteFile(tempConfigFile, data, 0644)
 	suite.Nil(err, fmt.Sprintf("no error creating new config file %s", tempConfigFile))
 	suite.TempConfigFile = tempConfigFile
 }

--- a/pkg/repo/chart_test.go
+++ b/pkg/repo/chart_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package repo
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -35,7 +35,7 @@ type ChartTestSuite struct {
 
 func (suite *ChartTestSuite) SetupSuite() {
 	tarballPath := "../../testdata/charts/mychart/mychart-0.1.0.tgz"
-	content, err := ioutil.ReadFile(tarballPath)
+	content, err := os.ReadFile(tarballPath)
 	suite.Nil(err, "no error reading test tarball")
 	suite.TarballContent = content
 }


### PR DESCRIPTION
The functions inside the `io/ioutil` package have been deprecated since 1.16.
`chartmuseum` is currently using go 1.19.