### PR TITLE
chore: replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/chartmuseum/auth v0.5.0
 	github.com/chartmuseum/storage v0.13.0
-	github.com/ghodss/yaml v1.0.0
 	github.com/gin-contrib/size v0.0.0-20220102055520-f75bacbc2df3
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-redis/redis v6.15.9+incompatible
@@ -19,6 +18,7 @@ require (
 	github.com/zsais/go-gin-prometheus v0.1.0
 	go.uber.org/zap v1.24.0
 	helm.sh/helm/v3 v3.11.3
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -180,5 +180,4 @@ require (
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -188,7 +188,6 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/size v0.0.0-20220102055520-f75bacbc2df3 h1:4qSA5YRz7fSzZAggntVXfz58ipC7bhrNvzj8aryaqSg=
 github.com/gin-contrib/size v0.0.0-20220102055520-f75bacbc2df3/go.mod h1:TNclj+D/YdCIzSgy+uog3TrPw30GpZjgcF/LXS3qpoA=

--- a/pkg/chartmuseum/server/multitenant/artifacthub.go
+++ b/pkg/chartmuseum/server/multitenant/artifacthub.go
@@ -19,7 +19,7 @@ package multitenant
 import (
 	"net/http"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	cm_logger "helm.sh/chartmuseum/pkg/chartmuseum/logger"
 	cm_repo "helm.sh/chartmuseum/pkg/repo"

--- a/pkg/chartmuseum/server/multitenant/cache.go
+++ b/pkg/chartmuseum/server/multitenant/cache.go
@@ -46,8 +46,8 @@ import (
 	cm_repo "helm.sh/chartmuseum/pkg/repo"
 
 	cm_storage "github.com/chartmuseum/storage"
-	"github.com/ghodss/yaml"
 	"github.com/gin-gonic/gin"
+	"sigs.k8s.io/yaml"
 
 	helm_repo "helm.sh/helm/v3/pkg/repo"
 )

--- a/pkg/chartmuseum/server/multitenant/server_test.go
+++ b/pkg/chartmuseum/server/multitenant/server_test.go
@@ -34,7 +34,7 @@ import (
 	"helm.sh/chartmuseum/pkg/repo"
 
 	"github.com/chartmuseum/storage"
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/suite"
 )

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	helm_repo "helm.sh/helm/v3/pkg/repo"
 )


### PR DESCRIPTION
The `github.com/ghodss/yaml` package is no longer being actively maintained. `sigs.k8s.io/yaml` is a permanent fork of `github.com/ghodss/yaml`, which is actively maintained by Kubernetes SIG and widely used in K8s projects.

The notable change is that `github.com/ghodss/yaml` uses `gopkg.in/yaml.v2 v2.2.2`, while `sigs.k8s.io/yaml` uses `gopkg.in/yaml.v2 v2.4.0`. You can see the changes between the two versions here: [v2.2.2...v2.4.0](https://github.com/go-yaml/yaml/compare/v2.2.2...v2.4.0), which mostly consists of bug fixes.