### PR TITLE
Add support for creating repository indexes in JSON format

### DIFF
--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -119,6 +119,7 @@ func cliHandler(c *cli.Context) {
 		WebTemplatePath:        conf.GetString("web-template-path"),
 		ArtifactHubRepoID:      conf.GetStringMapString("artifact-hub-repo-id"),
 		AlwaysRegenerateIndex:  conf.GetBool("always-regenerate-chart-index"),
+		JSONIndex:              conf.GetBool("json-index"),
 	}
 
 	server, err := newServer(options)

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -84,6 +84,7 @@ type (
 		// AlwaysRegenerateIndex represents if the museum always return the up-to-date chart
 		// which means that the GetChart will increase its latency , be careful to enable this .
 		AlwaysRegenerateIndex bool
+		JSONIndex             bool
 	}
 
 	// Server is a generic interface for web servers
@@ -151,6 +152,7 @@ func NewServer(options ServerOptions) (Server, error) {
 		// EnforceSemver2 - see https://github.com/helm/chartmuseum/issues/485 for more info
 		EnforceSemver2:        options.EnforceSemver2,
 		AlwaysRegenerateIndex: options.AlwaysRegenerateIndex,
+		JSONIndex:             options.JSONIndex,
 	})
 
 	return server, err

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -73,6 +73,7 @@ type (
 		EnforceSemver2        bool
 		WebTemplatePath       string
 		AlwaysRegenerateIndex bool
+		JSONIndex             bool
 	}
 
 	ObjectsPerChartLimit struct {
@@ -106,6 +107,7 @@ type (
 		// Deprecated: see https://github.com/helm/chartmuseum/issues/485 for more info
 		EnforceSemver2        bool
 		AlwaysRegenerateIndex bool
+		JSONIndex             bool
 	}
 
 	tenantInternals struct {
@@ -166,6 +168,7 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 		WebTemplatePath:        options.WebTemplatePath,
 		ArtifactHubRepoID:      options.ArtifactHubRepoID,
 		AlwaysRegenerateIndex:  options.AlwaysRegenerateIndex,
+		JSONIndex:              options.JSONIndex,
 	}
 
 	if server.WebTemplatePath != "" {

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -138,6 +138,15 @@ var configVars = map[string]configVar{
 			EnvVar: "DISABLE_STATEFILES",
 		},
 	},
+	"json-index": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "json-index",
+			Usage:  "generates an index in JSON format, improves parsing performance for large index files",
+			EnvVar: "JSON_INDEX",
+		},
+	},
 	"allowoverwrite": {
 		Type:    boolType,
 		Default: false,

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -52,7 +52,7 @@ type (
 		Raw        []byte `json:"c"`
 		ChartURL   string `json:"d"`
 		IndexLock  sync.RWMutex
-		outputJSON bool
+		OutputJSON bool
 	}
 )
 
@@ -75,7 +75,7 @@ func (index *Index) Regenerate() (err error) {
 	index.Generated = time.Now().Round(time.Second)
 
 	var raw []byte
-	if index.outputJSON {
+	if index.OutputJSON {
 		raw, err = json.Marshal(index.IndexFile)
 	} else {
 		raw, err = yaml.Marshal(index.IndexFile)

--- a/pkg/repo/index_test.go
+++ b/pkg/repo/index_test.go
@@ -51,7 +51,7 @@ func getChartVersion(name string, patch int, created time.Time) *helm_repo.Chart
 }
 
 func (suite *IndexTestSuite) SetupSuite() {
-	suite.Index = NewIndex("", "", &ServerInfo{})
+	suite.Index = NewIndex("", "", &ServerInfo{}, false)
 	now := time.Now()
 	for _, name := range []string{"a", "b", "c"} {
 		for i := 0; i < 10; i++ {
@@ -94,13 +94,13 @@ func (suite *IndexTestSuite) TestRemove() {
 }
 
 func (suite *IndexTestSuite) TestChartURLs() {
-	index := NewIndex("", "", &ServerInfo{})
+	index := NewIndex("", "", &ServerInfo{}, false)
 	chartVersion := getChartVersion("a", 0, time.Now())
 	index.AddEntry(chartVersion)
 	suite.Equal("charts/a-1.0.0.tgz",
 		index.Entries["a"][0].URLs[0], "relative chart url")
 
-	index = NewIndex("http://mysite.com:8080", "", &ServerInfo{})
+	index = NewIndex("http://mysite.com:8080", "", &ServerInfo{}, false)
 	chartVersion = getChartVersion("a", 0, time.Now())
 	index.AddEntry(chartVersion)
 	suite.Equal("http://mysite.com:8080/charts/a-1.0.0.tgz",
@@ -109,13 +109,13 @@ func (suite *IndexTestSuite) TestChartURLs() {
 
 func (suite *IndexTestSuite) TestServerInfo() {
 	serverInfo := &ServerInfo{}
-	index := NewIndex("", "", serverInfo)
+	index := NewIndex("", "", serverInfo, false)
 	suite.False(strings.Contains(string(index.Raw), "contextPath: /v1/helm"), "context path not in index")
 
 	serverInfo = &ServerInfo{
 		ContextPath: "/v1/helm",
 	}
-	index = NewIndex("", "", serverInfo)
+	index = NewIndex("", "", serverInfo, false)
 	suite.True(strings.Contains(string(index.Raw), "contextPath: /v1/helm"), "context path is in index")
 }
 


### PR DESCRIPTION
## What this PR does

Adds support for generating an index.yaml in JSON-format to improve parsing performance (client-side) by using the default json library. Related to https://github.com/helm/helm/pull/12245 and #738.

## Testing results

When templating releases for my personal projects, I noticed a ~27% speed improvement in direct comparison of the chartmuseum creating a YAML-formatted versus a JSON-formatted index.yaml.
To be specific, a (rather large) Helmfile release used to take around 6min38s (user time), now takes 5m12s.

## What was changed

A flag was added (`--json-index`) which defaults to `false`. When set to `true` chartmuseum will return the `index.yaml` with JSON-formatted content, as described in the PR mentionned above.
This change should be backwards compatible with all Helm-clients before 3.13.0, since YAML is a superset of JSON, meaning all JSON can be parsed using YAML parsers. To be able to fully take advantage of the performance improvement the client will have to be updated to Helm >3.13.0.