### PR TITLE
Bump version to prep for 0.16.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-VERSION ?= 0.16.2
+# TODO(cbuto): Pull from git tag to avoid needing to bump this prior to releasing
+VERSION ?= 0.16.3
 REVISION := $(shell git rev-parse --short HEAD;)
 
 BINDIR      := $(CURDIR)/bin
@@ -230,5 +231,3 @@ lint:
 		echo "golangci-lint is not installed, please install it from https://golangci-lint.run/usage/install/"; \
 		exit 1; \
 	fi
-
-

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ docker run --rm -it \
   -e STORAGE=local \
   -e STORAGE_LOCAL_ROOTDIR=/charts \
   -v $(pwd)/charts:/charts \
-  ghcr.io/helm/chartmuseum:v0.16.2
+  ghcr.io/helm/chartmuseum:v0.16.3
 ```
 
 Example usage (S3):
@@ -485,7 +485,7 @@ docker run --rm -it \
   -e STORAGE_AMAZON_PREFIX="" \
   -e STORAGE_AMAZON_REGION="us-east-1" \
   -v ~/.aws:/home/chartmuseum/.aws:ro \
-  ghcr.io/helm/chartmuseum:v0.16.2
+  ghcr.io/helm/chartmuseum:v0.16.3
 ```
 
 ### Helm Chart


### PR DESCRIPTION
Bumps version to prep for 0.16.3

part of https://github.com/helm/chartmuseum/issues/1068