### PR TITLE
Clean up disk space in build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ jobs:
       packages: write
       id-token: write
     steps:
+      - name: Reclaim disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
       - name: Checkout
         uses: actions/checkout@v2
       - name: setup go environment


### PR DESCRIPTION
The build action keeps running out of disk space on main https://github.com/helm/chartmuseum/actions/runs/14735021721

This PR adds a step to remove some default dirs to hopefully clean up enough space so the action can finish.