### PR TITLE
fix: ensure proper prefix for tenant repositories in storage operations

### DIFF
--- a/pkg/chartmuseum/server/multitenant/api.go
+++ b/pkg/chartmuseum/server/multitenant/api.go
@@ -197,7 +197,12 @@ func (server *MultiTenantServer) uploadProvenanceFile(log cm_logger.LoggingFn, r
 
 func (server *MultiTenantServer) checkStorageLimit(repo string, filename string, force bool) (bool, error) {
 	if server.MaxStorageObjects > 0 {
-		allObjects, err := server.StorageBackend.ListObjects(repo)
+		// Ensure proper prefix for tenant repos by adding trailing slash
+		prefix := repo
+		if repo != "" {
+			prefix = repo + "/"
+		}
+		allObjects, err := server.StorageBackend.ListObjects(prefix)
 		if err != nil {
 			return false, err
 		}
@@ -246,7 +251,12 @@ func (server *MultiTenantServer) PutWithLimit(ctx *gin.Context, log cm_logger.Lo
 	defer server.ChartLimits.Unlock()
 	// clean the oldest chart(both index and storage)
 	// storage cache first
-	objs, err := server.StorageBackend.ListObjects(repo)
+	// Ensure proper prefix for tenant repos by adding trailing slash
+	prefix := repo
+	if repo != "" {
+		prefix = repo + "/"
+	}
+	objs, err := server.StorageBackend.ListObjects(prefix)
 	if err != nil {
 		return err
 	}

--- a/pkg/chartmuseum/server/multitenant/cache.go
+++ b/pkg/chartmuseum/server/multitenant/cache.go
@@ -198,7 +198,12 @@ func (server *MultiTenantServer) fetchChartsInStorage(log cm_logger.LoggingFn, r
 	log(cm_logger.DebugLevel, "Fetching chart list from storage",
 		"repo", repo,
 	)
-	allObjects, err := server.StorageBackend.ListObjects(repo)
+	// Ensure proper prefix for tenant repos by adding trailing slash
+	prefix := repo
+	if repo != "" {
+		prefix = repo + "/"
+	}
+	allObjects, err := server.StorageBackend.ListObjects(prefix)
 	if err != nil {
 		return []cm_storage.Object{}, err
 	}


### PR DESCRIPTION
This PR fixes a critical tenant isolation bug in ChartMuseum:

Before the fix:

- When listing charts for tenant "abc", ChartMuseum incorrectly included any chart that started with "abc" (like "abc-def-1.1.1.tgz") even if it was in the root directory
- This was a security issue as tenants could potentially see charts they shouldn't have access to

After the fix:

- ChartMuseum now properly isolates tenant charts by only including charts that are actually inside the tenant's directory
- For example, for tenant "abc", only charts inside the "abc/" directory are included
- Charts in the root that just happen to start with "abc" are correctly excluded

To make it super clear:

```
Before Fix:
└── bucket
    ├── abc-def-1.1.1.tgz    ❌ (ChartMuseum wrongly included these)
    ├── abc-def-1.1.24.tgz   ❌ (because they start with "abc")
    └── abc/
        └── xyz-1.1.1.tgz    ✅ (should only include this)

After Fix:
└── bucket
    ├── abc-def-1.1.1.tgz    ✅ (ChartMuseum correctly ignores these)
    ├── abc-def-1.1.24.tgz   ✅ (because they're not in the abc/ folder)
    └── abc/
        └── xyz-1.1.1.tgz    ✅ (only includes this, as it should!)
```