### PR TITLE
build: update Docker image tags to always use 'latest' for most recen…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,12 @@ jobs:
           DOCKER_IMAGE=ghcr.io/helm/chartmuseum
           DOCKER_PLATFORMS=linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386
           VERSION=canary
+          TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
 
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
+            TAGS="--tag ${DOCKER_IMAGE}:${VERSION} --tag ${DOCKER_IMAGE}:latest"
           fi
-
-          TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
 
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
           echo ::set-output name=version::${VERSION}
@@ -77,9 +77,7 @@ jobs:
       - name: Install Kubernetes SBOM Tool
         uses: puerco/bom-installer@aa0837e37b6965b5fc50adfad0683ec3c0a2c2c4
       - name: Install sigstore cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-version: 'v2.2.4'
+        uses: sigstore/cosign-installer@v3.8.1
       - name: Release artifacts (includes SBOM and signatures)
         id: release-artifacts
         env:
@@ -92,12 +90,18 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          cosign sign --yes ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+          for TAG in ${{ steps.prepare.outputs.version }} latest; do
+            [[ $TAG == latest && ${{ steps.prepare.outputs.version }} == "canary" ]] && continue
+            cosign sign --yes ${{ steps.prepare.outputs.docker_image }}:${TAG}
+          done
       - name: Attach SBOM to published images
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          cosign attach sbom --sbom _dist/chartmuseum-${{ steps.prepare.outputs.version }}.spdx ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+          for TAG in ${{ steps.prepare.outputs.version }} latest; do
+            [[ $TAG == latest && ${{ steps.prepare.outputs.version }} == "canary" ]] && continue
+            cosign attach sbom --sbom _dist/chartmuseum-${{ steps.prepare.outputs.version }}.spdx ${{ steps.prepare.outputs.docker_image }}:${TAG}
+          done
       - name: Clear
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ docker run --rm -it \
   -e STORAGE=local \
   -e STORAGE_LOCAL_ROOTDIR=/charts \
   -v $(pwd)/charts:/charts \
-  ghcr.io/helm/chartmuseum:v0.16.3
+  ghcr.io/helm/chartmuseum:latest  # always pulls most recent release
 ```
 
 Example usage (S3):
@@ -485,7 +485,7 @@ docker run --rm -it \
   -e STORAGE_AMAZON_PREFIX="" \
   -e STORAGE_AMAZON_REGION="us-east-1" \
   -v ~/.aws:/home/chartmuseum/.aws:ro \
-  ghcr.io/helm/chartmuseum:v0.16.3
+  ghcr.io/helm/chartmuseum:latest  # always pulls most recent release
 ```
 
 ### Helm Chart

--- a/scripts/sbom.sh
+++ b/scripts/sbom.sh
@@ -29,6 +29,12 @@ echo "Adding image ghcr.io/helm/chartmuseum:${VERSION}"
 echo "  - type: image" >> .sbom.yaml
 echo "    source: ghcr.io/helm/chartmuseum:${VERSION}" >> .sbom.yaml
 
+if [[ "${VERSION}" != "canary" ]]; then
+  echo "Adding image ghcr.io/helm/chartmuseum:latest"
+  echo "  - type: image" >> .sbom.yaml
+  echo "    source: ghcr.io/helm/chartmuseum:latest" >> .sbom.yaml
+fi
+
 echo "Wrote configuration file:"
 cat .sbom.yaml
 


### PR DESCRIPTION
This PR adds support for the `:latest` tag on container images, which will always point to the most recent stable release. Key changes:

1. GitHub Actions workflow:

   - Adds `:latest` tag alongside version tag (e.g. `:v0.16.3`) for release builds only
   - Skips `:latest` tag for canary builds from main branch
   - Updates cosign installer to v3.1.1 to fix version compatibility
   - Modifies signing and SBOM steps to handle both version and latest tags

2. SBOM generation:

   - Adds latest tag to SBOM metadata for release builds
   - Skips latest tag for canary builds to maintain stability

3. Documentation:

   - Updates Docker examples to demonstrate latest tag usage
   - Adds comments explaining that latest always pulls most recent release

This change makes it easier for users to always pull the most recent stable release using:

```bash
docker pull ghcr.io/helm/chartmuseum:latest
```
